### PR TITLE
Create event/<key>/participants resource.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/Permission.java
+++ b/src/main/java/org/karmaexchange/dao/Permission.java
@@ -1,7 +1,24 @@
 package org.karmaexchange.dao;
 
 public enum Permission {
-  READ,
-  EDIT,
-  ALL
+  READ {
+    @Override
+    public boolean canEdit() {
+      return false;
+    }
+  },
+  EDIT {
+    @Override
+    public boolean canEdit() {
+      return true;
+    }
+  },
+  ALL {
+    @Override
+    public boolean canEdit() {
+      return true;
+    }
+  };
+
+  public abstract boolean canEdit();
 }


### PR DESCRIPTION
Added participant view CRUD for all types of participants

Details: 
- Supports pagination. 
- Transactional.
- Organizers can manipulate any list and the limits for the event are not enforced. Limits are only enforced when non-organizers try to add themselves to the registered user list or the wait list.

GET
/event/<key>/participants/ORGANIZER?limit=N
/event/<key>/participants/REGISTERED?limit=N
/event/<key>/participants/WAIT_LISTED?limit=N

POST
/event/<key>/participants/ORGANIZER?user=key
/event/<key>/participants/REGISTERED?user=key
/event/<key>/participants/WAIT_LISTED?user=key

DELETE
/event/<key>/participants?user=key

Param details:
- user defaults to me if not specified
- next url will be available if there are more users. Use the limit to minimize the number of fetches of user objects.
