### PR TITLE
Transactional event updates

### DIFF
--- a/src/main/java/org/karmaexchange/dao/BaseDao.java
+++ b/src/main/java/org/karmaexchange/dao/BaseDao.java
@@ -5,12 +5,17 @@ import static org.karmaexchange.util.OfyService.ofy;
 
 import java.util.List;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import org.karmaexchange.dao.Event.DeleteParticipantTxn;
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 
 import com.google.common.collect.Lists;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.Objectify;
+import com.googlecode.objectify.VoidWork;
 import com.googlecode.objectify.cmd.Query;
 
 public abstract class BaseDao<T extends BaseDao<T>> {
@@ -42,15 +47,24 @@ public abstract class BaseDao<T extends BaseDao<T>> {
           ErrorInfo.Type.BAD_REQUEST);
       }
     }
+    ofy().transact(new UpsertTxn<T>(resource));
+  }
 
-    T prevResource = null;
-    if (resource.getId() != null) {
-      prevResource = load(Key.create(resource));
-    }
-    if (prevResource == null) {
-      resource.insert();
-    } else {
-      resource.update(prevResource);
+  @Data
+  @EqualsAndHashCode(callSuper=false)
+  public static class UpsertTxn<T extends BaseDao<T>> extends VoidWork {
+    private final T resource;
+
+    public void vrun() {
+      T prevResource = null;
+      if (resource.getId() != null) {
+        prevResource = load(Key.create(resource));
+      }
+      if (prevResource == null) {
+        resource.insert();
+      } else {
+        resource.update(prevResource);
+      }
     }
   }
 
@@ -101,13 +115,13 @@ public abstract class BaseDao<T extends BaseDao<T>> {
     return resource;
   }
 
-  void insert() {
+  final void insert() {
     preProcessInsert();
     ofy().save().entity(this).now();
     postProcessInsert();
   }
 
-  public final void update(T prevObj) {
+  final void update(T prevObj) {
     processUpdate(prevObj);
     ofy().save().entity(this).now();
   }

--- a/src/main/java/org/karmaexchange/dao/BaseDao.java
+++ b/src/main/java/org/karmaexchange/dao/BaseDao.java
@@ -8,7 +8,6 @@ import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import org.karmaexchange.dao.Event.DeleteParticipantTxn;
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 

--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -124,7 +124,7 @@ public class EventResource extends BaseDaoResource<Event> {
     checkState((limit >= 0) && (offset >= 0), "limit and offset must be non-negative");
     List<KeyWrapper<User>> participants = event.getParticipants(participantType);
     List<KeyWrapper<User>> offsettedResult =
-        PagingInfo.getOffsettedResult(participants, offset, limit);
+        PagingInfo.createOffsettedResult(participants, offset, limit);
     return ListResponseMsg.create(
       EventParticipantView.get(offsettedResult),
       PagingInfo.create(offset, limit, participants.size(), uriInfo.getAbsolutePath(), null));

--- a/src/main/java/org/karmaexchange/resources/MeResource.java
+++ b/src/main/java/org/karmaexchange/resources/MeResource.java
@@ -1,5 +1,6 @@
 package org.karmaexchange.resources;
 
+import static java.lang.String.format;
 import static org.karmaexchange.resources.BaseDaoResource.DEFAULT_NUM_SEARCH_RESULTS;
 import static org.karmaexchange.util.OfyService.ofy;
 import static org.karmaexchange.util.UserService.getCurrentUser;
@@ -21,10 +22,13 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.resources.EventResource.EventSearchType;
+import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.EventSearchView;
 import org.karmaexchange.resources.msg.ListResponseMsg;
+import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 import org.karmaexchange.resources.msg.ListResponseMsg.PagingInfo;
 
 import com.google.common.collect.Maps;
@@ -45,8 +49,14 @@ public class MeResource {
 
   @POST
   @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-  public Response upsertResource(User updatedUser) {
-    updatedUser.update(getCurrentUser());
+  public Response updateResource(User updatedUser) {
+    if (!getCurrentUserKey().getString().equals(updatedUser.getKey())) {
+      throw ErrorResponseMsg.createException(
+        format("thew new resource key [%s] does not match the previous key [%s]",
+          getCurrentUserKey().getString(), updatedUser.getKey()),
+        ErrorInfo.Type.BAD_REQUEST);
+    }
+    BaseDao.upsert(updatedUser);
     return Response.ok().build();
   }
 

--- a/src/main/java/org/karmaexchange/resources/msg/ListResponseMsg.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ListResponseMsg.java
@@ -76,8 +76,8 @@ public class ListResponseMsg<T> {
     public static PagingInfo create(int currentOffset, int limit, int listSize,
                                     URI resourceUri, @Nullable Map<String, Object> params) {
       int nextOffset = currentOffset + limit;
-      boolean moreResults = listSize > nextOffset;
-      if (!moreResults) {
+      if (nextOffset >= listSize) {
+        // No more results.
         return null;
       }
       Map<String, Object> finalParams =
@@ -88,7 +88,7 @@ public class ListResponseMsg<T> {
       return new PagingInfo(nextUrl, null);
     }
 
-    public static <T> List<T> getOffsettedResult(List<T> result, int offset, int limit) {
+    public static <T> List<T> createOffsettedResult(List<T> result, int offset, int limit) {
       if (offset >= result.size()) {
         return result.subList(0, 0);
       } else {

--- a/src/main/java/org/karmaexchange/security/OAuthFilter.java
+++ b/src/main/java/org/karmaexchange/security/OAuthFilter.java
@@ -18,6 +18,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
+import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.OAuthCredential;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.provider.SocialNetworkProvider;
@@ -134,6 +135,7 @@ public class OAuthFilter implements Filter {
    */
   private static User createUser(OAuthCredential credential) {
     User user = SocialNetworkProviderFactory.getProvider(credential).initUser();
+    // getCurrentUserKey() is not setup at this point so we can't use BaseDao.upsert().
     ofy().save().entity(user).now();
     return user;
   }
@@ -142,6 +144,9 @@ public class OAuthFilter implements Filter {
     for (OAuthCredential credential : user.getOauthCredentials()) {
       if (credential.getGlobalUid().equals(newCredential.getGlobalUid())) {
         credential.setToken(newCredential.getToken());
+        // getCurrentUserKey() is not setup at this point so we can't use BaseDao.upsert().
+        // TODO(avaliani): consider moving this to a new non user object. This way we don't
+        //     violate the atomicity of user object updates.
         ofy().save().entity(user).now();
         return;
       }

--- a/src/main/java/org/karmaexchange/security/OAuthFilter.java
+++ b/src/main/java/org/karmaexchange/security/OAuthFilter.java
@@ -18,7 +18,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
-import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.OAuthCredential;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.provider.SocialNetworkProvider;


### PR DESCRIPTION
- Updates to event objects are now transactional. Any updates to the “participants” field will be ignored. Instead, in order to update the participants field for an existing event the /event/<key>/participants CRUD must be used.
- User object edits would also be transactional with this merge if we didn’t have the non-transactional update in the OAuthFilter... which can’t be simply changed because of a bootstrapping issue with getCurrentUserKey() for the modification timestamp.
