### PR TITLE
Fix bug with the Event class failing to compile because of an issue with...

### DIFF
--- a/src/main/java/org/karmaexchange/dao/Event.java
+++ b/src/main/java/org/karmaexchange/dao/Event.java
@@ -13,7 +13,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
-import org.karmaexchange.dao.Event.EventParticipant.ParticipantType;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -488,12 +487,11 @@ public final class Event extends BaseDao<Event> {
         }
       };
     }
-
-    public enum ParticipantType {
-      ORGANIZER,
-      REGISTERED,
-      WAIT_LISTED
-    }
   }
 
+  public enum ParticipantType {
+    ORGANIZER,
+    REGISTERED,
+    WAIT_LISTED
+  }
 }

--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response;
 
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.BaseDao;
-import org.karmaexchange.dao.Event.EventParticipant.ParticipantType;
+import org.karmaexchange.dao.Event.ParticipantType;
 import org.karmaexchange.dao.Event.UpsertParticipantTxn;
 import org.karmaexchange.dao.Event.DeleteParticipantTxn;
 import org.karmaexchange.dao.KeyWrapper;


### PR DESCRIPTION
Fix bug with the Event class failing to compile because of an issue with annotation parsing.

Details:
The annotations failed to parse because there was a public enum inside the class. So strange! I will post to stackoverflow.
