### PR TITLE
Image upload infrastructure + profile image CRUD

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
 			<version>2.0.1</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>commons-fileupload</groupId>
+			<artifactId>commons-fileupload</artifactId>
+			<version>1.3</version>
+		</dependency>
 
 		<!-- Test Dependencies -->
 		<dependency>

--- a/src/main/java/org/karmaexchange/dao/Event.java
+++ b/src/main/java/org/karmaexchange/dao/Event.java
@@ -1,6 +1,5 @@
 package org.karmaexchange.dao;
 
-import static org.karmaexchange.util.OfyService.ofy;
 import static org.karmaexchange.util.UserService.getCurrentUserKey;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -29,6 +28,8 @@ import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Index;
 
+// TODO(avlaiani):
+//   - Fix EventSearchView for images once we revamp it.
 @XmlRootElement
 @Entity
 @Data
@@ -166,12 +167,9 @@ public final class Event extends BaseDao<Event> {
     validateEvent();
   }
 
-  /** Persist the new participant list to the datastore. */
   private void updateParticipants() {
-    super.processUpdate(this);
     processParticipants();
     validateEvent();
-    ofy().save().entity(this).now();
   }
 
   private void processParticipants() {
@@ -381,7 +379,7 @@ public final class Event extends BaseDao<Event> {
     private final ParticipantType participantType;
 
     public void vrun() {
-      Event event = load(eventKey);
+      Event event = BaseDao.load(eventKey);
       if (event == null) {
         throw ErrorResponseMsg.createException("event not found",
           ErrorInfo.Type.BAD_REQUEST);
@@ -432,6 +430,7 @@ public final class Event extends BaseDao<Event> {
       }
       // validateEvent() ensures that there is at least one organizer.
       event.updateParticipants();
+      BaseDao.partialUpdate(event);
     }
   }
 
@@ -442,7 +441,7 @@ public final class Event extends BaseDao<Event> {
     private final Key<User> userToRemoveKey;
 
     public void vrun() {
-      Event event = load(eventKey);
+      Event event = BaseDao.load(eventKey);
       if (event == null) {
         throw ErrorResponseMsg.createException("event not found",
           ErrorInfo.Type.BAD_REQUEST);
@@ -458,6 +457,7 @@ public final class Event extends BaseDao<Event> {
         event.participants.remove(participant);
         // validateEvent() ensures that there is at least one organizer.
         event.updateParticipants();
+        BaseDao.partialUpdate(event);
       }
     }
   }

--- a/src/main/java/org/karmaexchange/dao/Image.java
+++ b/src/main/java/org/karmaexchange/dao/Image.java
@@ -34,9 +34,6 @@ import com.googlecode.objectify.annotation.Parent;
 //   Note that equalsAndHashCode would then need to call super.
 //
 // 1.b. Re-eval setId() overriding.
-//
-// 2. Verify that no index is required if we do an ancestor query and sort by dateuploaded.
-//    Not true. it's app/kind that's the prefix. Not app/parent/kind
 @XmlRootElement
 @Entity
 @Data
@@ -44,14 +41,6 @@ import com.googlecode.objectify.annotation.Parent;
 @EqualsAndHashCode(callSuper=false)
 public class Image extends BaseDao<Image> {
 
-  // Bootstrapping problem for user object. Need to save it to create image object.
-  //   - createUserPreBootstrap
-  //   - updateCreatedUserPostBootstrap
-  //
-  // TODO(avaliani): fix image bootstrap
-  //   Better:
-  //   - initUser
-  //   - User.setProfileImage(SocialNetworkProvider.getProfileImage())
   @Parent
   Key<?> owner;
   @Id
@@ -134,7 +123,7 @@ public class Image extends BaseDao<Image> {
   @Override
   protected void processUpdate(Image prevObj) {
     super.processUpdate(prevObj);
-    // Some fields can not be modified. The image can be deleted.
+    // Some fields can not be modified.
     blobKey = prevObj.blobKey;
     url = prevObj.url;
     urlProvider = prevObj.urlProvider;

--- a/src/main/java/org/karmaexchange/dao/ImageRef.java
+++ b/src/main/java/org/karmaexchange/dao/ImageRef.java
@@ -1,0 +1,38 @@
+package org.karmaexchange.dao;
+
+import javax.annotation.Nullable;
+
+import org.karmaexchange.dao.Image.ImageProviderType;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Embed;
+import com.googlecode.objectify.annotation.Index;
+
+@Data
+@Embed
+@NoArgsConstructor
+public class ImageRef {
+  @Index
+  KeyWrapper<Image> image;
+  private String url;
+  private ImageProviderType urlProvider;
+
+  public static ImageRef create(Image image) {
+    return new ImageRef(image);
+  }
+
+  private ImageRef(Image image) {
+    this.image = KeyWrapper.create(image);
+    this.url = image.getUrl();
+    this.urlProvider = image.getUrlProvider();
+  }
+
+  public static void updateRefs(Key<Image> oldRef, @Nullable Key<Image> newRef) {
+    // TODO(avaliani):
+    // - do this in a transactional task queue.
+    // - only update refs with events with startTime > now. This will reduce the cost.
+  }
+}

--- a/src/main/java/org/karmaexchange/dao/ParticipantImage.java
+++ b/src/main/java/org/karmaexchange/dao/ParticipantImage.java
@@ -4,7 +4,7 @@ import javax.annotation.Nullable;
 
 import lombok.Data;
 
-import org.karmaexchange.dao.Image.ImageProvider;
+import org.karmaexchange.dao.Image.ImageProviderType;
 
 import com.google.common.base.Predicate;
 import com.googlecode.objectify.annotation.Embed;
@@ -14,17 +14,15 @@ import com.googlecode.objectify.annotation.Embed;
 public class ParticipantImage {
   private KeyWrapper<User> participant;
   private String imageUrl;
-  private ImageProvider imageUrlProvider;
+  private ImageProviderType imageUrlProvider;
 
   public static ParticipantImage create(User participant) {
     ParticipantImage participantImage = new ParticipantImage();
-    Image profileImage = participant.getProfileImage();
+    ImageRef profileImageRef = participant.getProfileImage();
     participantImage.setParticipant(KeyWrapper.create(participant));
-    // Note that every non-test user will have a social network provided url. So there's no
-    // reason to return null if the profileImage is null.
-    if (profileImage != null) {
-      participantImage.setImageUrl(profileImage.getUrl());
-      participantImage.setImageUrlProvider(profileImage.getUrlProvider());
+    if (profileImageRef != null) {
+      participantImage.setImageUrl(profileImageRef.getUrl());
+      participantImage.setImageUrlProvider(profileImageRef.getUrlProvider());
     }
     return participantImage;
   }

--- a/src/main/java/org/karmaexchange/provider/FacebookSocialNetworkProvider.java
+++ b/src/main/java/org/karmaexchange/provider/FacebookSocialNetworkProvider.java
@@ -12,10 +12,11 @@ import org.karmaexchange.dao.Address;
 import org.karmaexchange.dao.ContactInfo;
 import org.karmaexchange.dao.GeoPtWrapper;
 import org.karmaexchange.dao.Image;
-import org.karmaexchange.dao.Image.ImageProvider;
+import org.karmaexchange.dao.Image.ImageProviderType;
 import org.karmaexchange.dao.ModificationInfo;
 import org.karmaexchange.dao.OAuthCredential;
 import org.karmaexchange.dao.User;
+import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 
@@ -36,8 +37,9 @@ public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
 
   private static final String PROFILE_IMAGE_URL_FMT = "https://graph.facebook.com/%s/picture";
 
-  public FacebookSocialNetworkProvider(OAuthCredential credential) {
-    super(credential);
+  public FacebookSocialNetworkProvider(OAuthCredential credential,
+      SocialNetworkProviderType providerType) {
+    super(credential, providerType);
   }
 
   @Override
@@ -76,8 +78,6 @@ public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
     //   - email
     //   - location
     contactInfo.setEmail(fbUser.getEmail());
-    Image image = Image.create(buildImageUrl(credential.getUid()), ImageProvider.FACEBOOK);
-    user.setProfileImage(image);
 
     NamedFacebookType fbLocationKey = fbUser.getLocation();
     // TODO(avaliani): fix this
@@ -89,8 +89,9 @@ public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
     return user;
   }
 
-  private String buildImageUrl(String uid) {
-    return String.format(PROFILE_IMAGE_URL_FMT, uid);
+  @Override
+  public String getProfileImageUrl() {
+    return String.format(PROFILE_IMAGE_URL_FMT, credential.getUid());
   }
 
   private Address initAddress(DefaultFacebookClient fbClient, NamedFacebookType fbLocationKey) {

--- a/src/main/java/org/karmaexchange/provider/SocialNetworkProvider.java
+++ b/src/main/java/org/karmaexchange/provider/SocialNetworkProvider.java
@@ -5,12 +5,33 @@ import org.karmaexchange.dao.User;
 
 public abstract class SocialNetworkProvider {
   protected OAuthCredential credential;
+  private SocialNetworkProviderType providerType;
 
-  protected SocialNetworkProvider(OAuthCredential credential) {
+  /* If a new SocialNetworkProviderType is added, make sure to modify ImageProviderType */
+  public enum SocialNetworkProviderType {
+    FACEBOOK {
+      @Override
+      public SocialNetworkProvider getProvider(OAuthCredential credential) {
+        return new FacebookSocialNetworkProvider(credential, this);
+      }
+    };
+
+    public abstract SocialNetworkProvider getProvider(OAuthCredential credential);
+  }
+
+  protected SocialNetworkProvider(OAuthCredential credential,
+      SocialNetworkProviderType providerType) {
     this.credential = credential;
+    this.providerType = providerType;
+  }
+
+  public SocialNetworkProviderType getProviderType() {
+    return providerType;
   }
 
   public abstract boolean verifyCredential();
 
   public abstract User initUser();
+
+  public abstract String getProfileImageUrl();
 }

--- a/src/main/java/org/karmaexchange/provider/SocialNetworkProviderFactory.java
+++ b/src/main/java/org/karmaexchange/provider/SocialNetworkProviderFactory.java
@@ -6,6 +6,9 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import org.karmaexchange.dao.OAuthCredential;
+import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
+import org.karmaexchange.resources.msg.ErrorResponseMsg;
+import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 
 import com.google.common.collect.Maps;
 
@@ -15,13 +18,17 @@ public final class SocialNetworkProviderFactory {
   private static final String OAUTH_TOKEN_SUFFIX = "token";
   private static final String OAUTH_LOGIN = "login";
 
-  private static final String FACEBOOK_PROVIDER = "facebook";
-
   public static SocialNetworkProvider getProvider(OAuthCredential credential) {
-    if (credential.getProvider().equals(FACEBOOK_PROVIDER)) {
-      return new FacebookSocialNetworkProvider(credential);
-    } else {
-      return null;
+    return getProviderType(credential).getProvider(credential);
+  }
+
+  public static SocialNetworkProviderType getProviderType(OAuthCredential credential) {
+    try {
+      return SocialNetworkProviderType.valueOf(credential.getProvider().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw ErrorResponseMsg.createException(
+        "unknown social network provider type: " + credential.getProvider(),
+        ErrorInfo.Type.BAD_REQUEST);
     }
   }
 

--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -111,11 +111,11 @@ public class EventResource extends BaseDaoResource<Event> {
       PagingInfo.create(afterCursor, limit, queryIter.hasNext(), baseUri, paginationParams));
   }
 
-  @Path("{resource}/participants/{participant_type}")
+  @Path("{event_key}/participants/{participant_type}")
   @GET
   @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
   public ListResponseMsg<EventParticipantView> getParticipants(
-      @PathParam("resource") String eventKeyStr,
+      @PathParam("event_key") String eventKeyStr,
       @PathParam("participant_type") ParticipantType participantType,
       @QueryParam(PagingInfo.OFFSET_PARAM) @DefaultValue("0") int offset,
       @QueryParam(PagingInfo.LIMIT_PARAM)
@@ -130,11 +130,11 @@ public class EventResource extends BaseDaoResource<Event> {
       PagingInfo.create(offset, limit, participants.size(), uriInfo.getAbsolutePath(), null));
   }
 
-  @Path("{resource}/participants/{participant_type}")
+  @Path("{event_key}/participants/{participant_type}")
   @POST
   @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
   public Response upsertParticipants(
-      @PathParam("resource") String eventKeyStr,
+      @PathParam("event_key") String eventKeyStr,
       @PathParam("participant_type") ParticipantType participantType,
       @QueryParam("user") String userKeyStr) {
     Key<User> userKey = (userKeyStr == null) ? getCurrentUserKey() : Key.<User>create(userKeyStr);
@@ -143,10 +143,10 @@ public class EventResource extends BaseDaoResource<Event> {
     return Response.ok().build();
   }
 
-  @Path("{resource}/participants")
+  @Path("{event_key}/participants")
   @DELETE
   public void deleteParticipants(
-      @PathParam("resource") String eventKeyStr,
+      @PathParam("event_key") String eventKeyStr,
       @QueryParam("user") String userKeyStr) {
     Key<User> userKey = (userKeyStr == null) ? getCurrentUserKey() : Key.<User>create(userKeyStr);
     ofy().transact(new DeleteParticipantTxn(Key.<Event>create(eventKeyStr), userKey));

--- a/src/main/java/org/karmaexchange/resources/MeResource.java
+++ b/src/main/java/org/karmaexchange/resources/MeResource.java
@@ -8,6 +8,7 @@ import static org.karmaexchange.util.UserService.getCurrentUserKey;
 
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -24,13 +25,17 @@ import javax.ws.rs.core.UriInfo;
 
 import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.User;
+import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
 import org.karmaexchange.resources.EventResource.EventSearchType;
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.EventSearchView;
 import org.karmaexchange.resources.msg.ListResponseMsg;
 import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 import org.karmaexchange.resources.msg.ListResponseMsg.PagingInfo;
+import org.karmaexchange.util.ImageUploadUtil;
 
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import com.google.common.collect.Maps;
 
 @Path("/me")
@@ -62,9 +67,7 @@ public class MeResource {
 
   @DELETE
   public void deleteResource() {
-    ofy().delete().key(getCurrentUserKey()).now();
-    // TODO(avaliani): revoke OAuth credentials. This way the user account won't be re-created
-    //     automatically.
+    BaseDao.delete(getCurrentUserKey());
   }
 
   @Path("event")
@@ -79,5 +82,30 @@ public class MeResource {
     filters.put("participants.user.key", getCurrentUserKey());
     return EventResource.eventSearch(afterCursorStr, limit, startTimeValue,
       uriInfo.getAbsolutePath(), searchType, filters);
+  }
+
+  @Path("profile_image")
+  @POST
+  public Response updateProfileImage(
+      @QueryParam("provider") SocialNetworkProviderType providerType,
+      @Context HttpServletRequest servletRequest) {
+    if (providerType == null) {
+      BlobKey blobKey = ImageUploadUtil.persistImage(servletRequest);
+      try {
+        User.updateProfileImage(getCurrentUserKey(), blobKey);
+      } catch (RuntimeException e) {
+        BlobstoreServiceFactory.getBlobstoreService().delete(blobKey);
+        throw e;
+      }
+    } else {
+      User.updateProfileImage(getCurrentUserKey(), providerType);
+    }
+    return Response.ok().build();
+  }
+
+  @Path("profile_image")
+  @DELETE
+  public void deleteProfileImage() {
+    User.deleteProfileImage(getCurrentUserKey());
   }
 }

--- a/src/main/java/org/karmaexchange/resources/MeResource.java
+++ b/src/main/java/org/karmaexchange/resources/MeResource.java
@@ -2,7 +2,6 @@ package org.karmaexchange.resources;
 
 import static java.lang.String.format;
 import static org.karmaexchange.resources.BaseDaoResource.DEFAULT_NUM_SEARCH_RESULTS;
-import static org.karmaexchange.util.OfyService.ofy;
 import static org.karmaexchange.util.UserService.getCurrentUser;
 import static org.karmaexchange.util.UserService.getCurrentUserKey;
 

--- a/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
@@ -53,7 +53,7 @@ public class EventSearchView {
     searchView.setStartTime(event.getStartTime());
     searchView.setEndTime(event.getEndTime());
     if (event.getPrimaryImage() != null) {
-      searchView.setPrimaryImage(ImageUrlView.create(event.getPrimaryImage()));
+      // searchView.setPrimaryImage(ImageUrlView.create(event.getPrimaryImage()));
     }
     searchView.setKarmaPoints(event.getKarmaPoints());
     searchView.setCachedParticipantImages(event.getCachedParticipantImages());

--- a/src/main/java/org/karmaexchange/resources/msg/ImageUrlView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ImageUrlView.java
@@ -2,15 +2,15 @@ package org.karmaexchange.resources.msg;
 
 import lombok.Data;
 
-import org.karmaexchange.dao.Image;
-import org.karmaexchange.dao.Image.ImageProvider;
+import org.karmaexchange.dao.Image.ImageProviderType;
+import org.karmaexchange.dao.ImageRef;
 
 @Data
 public class ImageUrlView {
   private String url;
-  private ImageProvider urlProvider;
+  private ImageProviderType urlProvider;
 
-  public static ImageUrlView create(Image image) {
+  public static ImageUrlView create(ImageRef image) {
     ImageUrlView imageView = new ImageUrlView();
     imageView.setUrl(image.getUrl());
     imageView.setUrlProvider(image.getUrlProvider());

--- a/src/main/java/org/karmaexchange/task/DeleteBlobServlet.java
+++ b/src/main/java/org/karmaexchange/task/DeleteBlobServlet.java
@@ -1,0 +1,52 @@
+package org.karmaexchange.task;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.taskqueue.Queue;
+import com.google.appengine.api.taskqueue.QueueFactory;
+import com.google.appengine.api.taskqueue.TaskOptions;
+
+@SuppressWarnings("serial")
+public class DeleteBlobServlet extends HttpServlet {
+
+  private static final Logger logger = Logger.getLogger(DeleteBlobServlet.class.getName());
+
+  private static final String PATH = "/task/delete_blob";
+  private static final String BLOB_KEY_PARAM = "blob_key";
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    String blobKeyStr = req.getParameter(BLOB_KEY_PARAM);
+    if (blobKeyStr == null) {
+      logger.warning("no blob key specified");
+    } else {
+      BlobKey blobKey;
+      try {
+        blobKey = new BlobKey(blobKeyStr);
+      } catch (IllegalArgumentException e) {
+        logger.log(Level.WARNING, "unable to parse blob key: " + blobKeyStr, e);
+        return;
+      }
+      BlobstoreServiceFactory.getBlobstoreService().delete(blobKey);
+    }
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    doGet(req, resp);
+  }
+
+  public static void enqueueTask(BlobKey blobKey) {
+    Queue queue = QueueFactory.getDefaultQueue();
+    queue.add(TaskOptions.Builder.withUrl(DeleteBlobServlet.PATH)
+      .param(DeleteBlobServlet.BLOB_KEY_PARAM, blobKey.getKeyString()));
+  }
+}

--- a/src/main/java/org/karmaexchange/util/ImageUploadUtil.java
+++ b/src/main/java/org/karmaexchange/util/ImageUploadUtil.java
@@ -1,0 +1,107 @@
+package org.karmaexchange.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.apache.commons.fileupload.FileItemIterator;
+import org.apache.commons.fileupload.FileItemStream;
+import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload.util.Streams;
+import org.apache.commons.io.IOUtils;
+import org.karmaexchange.resources.msg.ErrorResponseMsg;
+import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
+
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.files.AppEngineFile;
+import com.google.appengine.api.files.FileService;
+import com.google.appengine.api.files.FileServiceFactory;
+import com.google.appengine.api.files.FileWriteChannel;
+import com.google.appengine.api.images.Image;
+import com.google.appengine.api.images.ImagesService;
+import com.google.appengine.api.images.ImagesServiceFactory;
+import com.google.appengine.api.images.Transform;
+import com.google.common.collect.Lists;
+
+public class ImageUploadUtil {
+  // Copy facebook which seems to use 2048.
+  private final static int DEFAULT_MAX_IMAGE_PX = 2048;
+
+  public static BlobKey persistImage(HttpServletRequest req) {
+    return persistImages(req, 1).get(0);
+  }
+
+  public static List<BlobKey> persistImages(HttpServletRequest req, int limit) {
+    return persistImages(req, limit, DEFAULT_MAX_IMAGE_PX, DEFAULT_MAX_IMAGE_PX, null);
+  }
+
+  public static List<BlobKey> persistImages(HttpServletRequest req, int limit, int maxWidthPx,
+      int maxHeightPx, @Nullable MultivaluedMap<String, String> formFields) {
+    List<BlobKey> blobKeys = Lists.newArrayList();
+    ServletFileUpload servletFileUpload = new ServletFileUpload();
+    try {
+      FileItemIterator fileIter = servletFileUpload.getItemIterator(req);
+      while (fileIter.hasNext()) {
+        FileItemStream item = fileIter.next();
+        InputStream stream = item.openStream();
+
+        if (item.isFormField()) {
+          if (formFields != null) {
+            formFields.add(item.getFieldName(), Streams.asString(stream));
+          }
+        } else {
+          Image image = processImage(stream, maxWidthPx, maxHeightPx);
+          blobKeys.add(writeToFile(image));
+        }
+      }
+    } catch(IOException e) {
+      deleteBlobs(blobKeys);
+      throw ErrorResponseMsg.createException(e, ErrorInfo.Type.BAD_REQUEST);
+    } catch(FileUploadException e) {
+      deleteBlobs(blobKeys);
+      throw ErrorResponseMsg.createException(e, ErrorInfo.Type.BAD_REQUEST);
+    }
+    if (blobKeys.size() == 0) {
+      throw ErrorResponseMsg.createException(
+        "request does not contain any images", ErrorInfo.Type.BAD_REQUEST);
+    }
+    return blobKeys;
+  }
+
+  private static void deleteBlobs(List<BlobKey> blobKeys) {
+    BlobstoreServiceFactory.getBlobstoreService().delete(blobKeys.toArray(new BlobKey[0]));
+  }
+
+  private static Image processImage(InputStream inputStream, int maxWidthPx, int maxHeightPx)
+      throws IOException {
+    ImagesService imagesService = ImagesServiceFactory.getImagesService();
+    Image inputImage = ImagesServiceFactory.makeImage(IOUtils.toByteArray(inputStream));
+    Transform resize = ImagesServiceFactory.makeResize(maxWidthPx, maxHeightPx);
+    return imagesService.applyTransform(resize, inputImage);
+  }
+
+  private static BlobKey writeToFile(Image image) throws IOException {
+    FileService fileService = FileServiceFactory.getFileService();
+    AppEngineFile file = fileService.createNewBlobFile(toMimeType(image.getFormat()));
+    FileWriteChannel writeChannel = fileService.openWriteChannel(file, true);
+    writeChannel.write(ByteBuffer.wrap(image.getImageData()));
+    writeChannel.closeFinally();
+    return fileService.getBlobKey(file);
+  }
+
+  private static String toMimeType(Image.Format format) {
+    switch (format) {
+      case ICO:
+        return "image/x-icon";
+      default:
+        return "image/" + format.name().toLowerCase();
+    }
+  }
+}

--- a/src/main/java/org/karmaexchange/util/OfyService.java
+++ b/src/main/java/org/karmaexchange/util/OfyService.java
@@ -4,6 +4,7 @@ package org.karmaexchange.util;
 import org.karmaexchange.dao.Cause;
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.EventComment;
+import org.karmaexchange.dao.Image;
 import org.karmaexchange.dao.NonProfitOrganization;
 import org.karmaexchange.dao.Organization;
 import org.karmaexchange.dao.Skill;
@@ -26,6 +27,7 @@ public class OfyService {
     ObjectifyService.register(Skill.class);
     ObjectifyService.register(Cause.class);
     ObjectifyService.register(EventComment.class);
+    ObjectifyService.register(Image.class);
   }
 
   public static Objectify ofy() {

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -25,18 +25,17 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
 			<param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
 			<param-value>true</param-value>
 		</init-param>
-
 		<load-on-startup>1</load-on-startup>
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>Jersey Web Application</servlet-name>
 		<url-pattern>/api/*</url-pattern>
 	</servlet-mapping>
+
 	<servlet>
 		<servlet-name>DeleteBlobServlet</servlet-name>
 		<servlet-class>org.karmaexchange.task.DeleteBlobServlet</servlet-class>
 	</servlet>
-
 	<servlet-mapping>
 		<servlet-name>DeleteBlobServlet</servlet-name>
 		<url-pattern>/task/delete_blob</url-pattern>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -9,10 +9,9 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
 		<filter-name>OAuthFilter</filter-name>
 		<filter-class>org.karmaexchange.security.OAuthFilter</filter-class>
 	</filter>
-
 	<filter-mapping>
 		<filter-name>OAuthFilter</filter-name>
-		<url-pattern>/*</url-pattern>
+		<url-pattern>/api/*</url-pattern>
 	</filter-mapping>
 
 	<servlet>
@@ -29,11 +28,28 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
 
 		<load-on-startup>1</load-on-startup>
 	</servlet>
-
 	<servlet-mapping>
 		<servlet-name>Jersey Web Application</servlet-name>
 		<url-pattern>/api/*</url-pattern>
 	</servlet-mapping>
+	<servlet>
+		<servlet-name>DeleteBlobServlet</servlet-name>
+		<servlet-class>org.karmaexchange.task.DeleteBlobServlet</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>DeleteBlobServlet</servlet-name>
+		<url-pattern>/task/delete_blob</url-pattern>
+	</servlet-mapping>
+
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/task/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>admin</role-name>
+        </auth-constraint>
+    </security-constraint>
 
 	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>

--- a/src/test/java/org/karmaexchange/dao/UserTest.java
+++ b/src/test/java/org/karmaexchange/dao/UserTest.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.karmaexchange.dao.Image.ImageProvider;
+import org.karmaexchange.dao.Image.ImageProviderType;
 import org.karmaexchange.util.DatastoreTestUtil;
 
 import com.google.appengine.api.datastore.GeoPt;
@@ -45,10 +45,11 @@ public class UserTest extends PersistenceTestHelper {
     modificationInfo.setLastModificationDate(creationDate);
 
     Image image = new Image();
+    image.setId((long) 1);
     image.setBlobKey("QsZLm_NXs4mCNc2idbG6gg");
     image.setUrl("http://completely_fake");
-    image.setUrlProvider(ImageProvider.BLOBSTORE);
-    user1.setProfileImage(image);
+    image.setUrlProvider(ImageProviderType.BLOBSTORE);
+    user1.setProfileImage(ImageRef.create(image));
 
     ContactInfo contactInfo = new ContactInfo();
     user1.setContactInfo(contactInfo);


### PR DESCRIPTION
Created the image upload infrastructure and image upload is supported for profile images. Events coming next!

**New crud:**

POST /api/me/profile_image?provider=FACEBOOK
  Sets the users image to their provider image. Default on creation.
or
POST /api/me/profile_image
  with an image as content for the POST request
  Sets the profile image to that content.

DELETE /api/me/profile_image
  deletes the profile image and leaves it cleared for the user.

DELETE /api/me
  auto deletes the profile image
