### PR TITLE
Improve event detail CRUDs.

### DIFF
--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -30,6 +30,7 @@ import org.karmaexchange.dao.KeyWrapper;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.resources.msg.EventParticipantView;
 import org.karmaexchange.resources.msg.EventSearchView;
+import org.karmaexchange.resources.msg.ExpandedEventSearchView;
 import org.karmaexchange.resources.msg.ListResponseMsg;
 import org.karmaexchange.resources.msg.ListResponseMsg.PagingInfo;
 
@@ -109,6 +110,15 @@ public class EventResource extends BaseDaoResource<Event> {
     return ListResponseMsg.create(
       EventSearchView.create(searchResults),
       PagingInfo.create(afterCursor, limit, queryIter.hasNext(), baseUri, paginationParams));
+  }
+
+  @Path("{event_key}/expanded_search_view")
+  @GET
+  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  public Response getExpandedEventSearchView(
+    @PathParam("event_key") String eventKeyStr) {
+    Event event = getResourceObj(eventKeyStr);
+    return Response.ok(ExpandedEventSearchView.create(event)).build();
   }
 
   @Path("{event_key}/participants/{participant_type}")

--- a/src/main/java/org/karmaexchange/resources/msg/EventParticipantView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventParticipantView.java
@@ -6,6 +6,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.KeyWrapper;
+import org.karmaexchange.dao.Rating;
 import org.karmaexchange.dao.User;
 
 import com.google.common.collect.Lists;
@@ -22,6 +23,7 @@ public class EventParticipantView {
   private String key;
   private ImageUrlView profileImage;
   private long karmaPoints;
+  private Rating eventOrganizerRating;
 
   public static List<EventParticipantView> get(List<KeyWrapper<User>> usersBatch) {
     List<EventParticipantView> registeredUsers = Lists.newArrayListWithCapacity(usersBatch.size());
@@ -34,16 +36,17 @@ public class EventParticipantView {
     return registeredUsers;
   }
 
-  private static EventParticipantView create(User user) {
-    EventParticipantView profileImageView = new EventParticipantView();
-    profileImageView.setFirstName(user.getFirstName());
-    profileImageView.setLastName(user.getLastName());
-    profileImageView.setNickName(user.getNickName());
-    profileImageView.setKey(user.getKey());
+  public static EventParticipantView create(User user) {
+    EventParticipantView participantView = new EventParticipantView();
+    participantView.setFirstName(user.getFirstName());
+    participantView.setLastName(user.getLastName());
+    participantView.setNickName(user.getNickName());
+    participantView.setKey(user.getKey());
     if (user.getProfileImage() != null) {
-      profileImageView.setProfileImage(ImageUrlView.create(user.getProfileImage()));
+      participantView.setProfileImage(ImageUrlView.create(user.getProfileImage()));
     }
-    profileImageView.setKarmaPoints(user.getKarmaPoints());
-    return profileImageView;
+    participantView.setKarmaPoints(user.getKarmaPoints());
+    participantView.setEventOrganizerRating(user.getEventOrganizerRating());
+    return participantView;
   }
 }

--- a/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
@@ -10,13 +10,16 @@ import org.karmaexchange.dao.Event.RegistrationInfo;
 import org.karmaexchange.dao.Location;
 import org.karmaexchange.dao.ParticipantImage;
 import org.karmaexchange.dao.Permission;
+import org.karmaexchange.dao.Rating;
 
 import com.google.common.collect.Lists;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @XmlRootElement
 @Data
+@NoArgsConstructor
 public class EventSearchView {
 
   private String key;
@@ -27,7 +30,6 @@ public class EventSearchView {
   private Date startTime;
   private Date endTime;
   private ImageUrlView primaryImage;
-  private int karmaPoints;
   private RegistrationInfo registrationInfo;
 
   private List<ParticipantImage> cachedParticipantImages = Lists.newArrayList();
@@ -36,31 +38,33 @@ public class EventSearchView {
   private int numRegistered;
   private int maxRegistrations;
 
+  private Rating eventRating;
+  private int karmaPoints;
+
   public static List<EventSearchView> create(List<Event> events) {
     List<EventSearchView> searchResults = Lists.newArrayListWithCapacity(events.size());
     for (Event event : events) {
-      searchResults.add(create(event));
+      searchResults.add(new EventSearchView(event));
     }
     return searchResults;
   }
 
-  private static EventSearchView create(Event event) {
-    EventSearchView searchView = new EventSearchView();
-    searchView.setKey(event.getKey());
-    searchView.setPermission(event.getPermission());
-    searchView.setTitle(event.getTitle());
-    searchView.setLocation(event.getLocation());
-    searchView.setStartTime(event.getStartTime());
-    searchView.setEndTime(event.getEndTime());
+  protected EventSearchView(Event event) {
+    key = event.getKey();
+    permission = event.getPermission();
+    title = event.getTitle();
+    location = event.getLocation();
+    startTime = event.getStartTime();
+    endTime = event.getEndTime();
     if (event.getPrimaryImage() != null) {
-      // searchView.setPrimaryImage(ImageUrlView.create(event.getPrimaryImage()));
+      // PrimaryImage(ImageUrlView.create(event.getPrimaryImage()));
     }
-    searchView.setKarmaPoints(event.getKarmaPoints());
-    searchView.setCachedParticipantImages(event.getCachedParticipantImages());
-    searchView.setNumAttending(event.getNumAttending());
-    searchView.setNumRegistered(event.getRegisteredUsers().size());
-    searchView.setMaxRegistrations(event.getMaxRegistrations());
-    searchView.setRegistrationInfo(event.getRegistrationInfo());
-    return searchView;
+    karmaPoints = event.getKarmaPoints();
+    cachedParticipantImages = event.getCachedParticipantImages();
+    numAttending = event.getNumAttending();
+    numRegistered = event.getRegisteredUsers().size();
+    maxRegistrations = event.getMaxRegistrations();
+    registrationInfo = event.getRegistrationInfo();
+    eventRating = event.getEventRating();
   }
 }

--- a/src/main/java/org/karmaexchange/resources/msg/ExpandedEventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ExpandedEventSearchView.java
@@ -1,0 +1,54 @@
+package org.karmaexchange.resources.msg;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.karmaexchange.dao.BaseDao;
+import org.karmaexchange.dao.Cause;
+import org.karmaexchange.dao.Event;
+import org.karmaexchange.dao.KeyWrapper;
+import org.karmaexchange.dao.Organization;
+import org.karmaexchange.dao.User;
+
+import com.google.common.collect.Lists;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@XmlRootElement
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper=true)
+@ToString(callSuper=true)
+public class ExpandedEventSearchView extends EventSearchView {
+  private String description;
+
+  private EventParticipantView firstOrganizer;
+  private int numOrganizers;
+
+  // TODO(avaliani): need to expand causes.
+  private List<KeyWrapper<Cause>> causes;
+  // TODO(avaliani): need to expand organizations.
+  private List<KeyWrapper<Organization>> organizations = Lists.newArrayList();
+
+  public static ExpandedEventSearchView create(Event event) {
+    return new ExpandedEventSearchView(event);
+  }
+
+  private ExpandedEventSearchView(Event event) {
+    super(event);
+    description = event.getDescription();
+
+    User user = BaseDao.load(KeyWrapper.toKey(event.getOrganizers().get(0)));
+    if (user != null) {
+      firstOrganizer = EventParticipantView.create(user);
+    }
+    numOrganizers = event.getOrganizers().size();
+
+    causes = event.getCauses();
+    organizations = event.getOrganizations();
+  }
+}


### PR DESCRIPTION
1.

GET /api/event/<id>/expanded_search_view

Provides all the details required for the expanded search. Including an auto-fetch of the first organizer's details, numOrganizers, and event description.

2.

EventParticipantView now contains the organizer rating also.
(/api/event/<id>/participants/<participant_type>)

This CRUD should be used for the event details page.

3.

EventSearchView - now has eventRating. So the rating can now be displayed for past events.
