### PR TITLE
Fix duplicate automatic user creation (caused by parallel UI requests)

### DIFF
--- a/src/main/java/org/karmaexchange/dao/BaseDao.java
+++ b/src/main/java/org/karmaexchange/dao/BaseDao.java
@@ -1,9 +1,8 @@
 package org.karmaexchange.dao;
 
 import static java.lang.String.format;
-import static org.karmaexchange.util.AdminUtil.isAdminKey;
 import static org.karmaexchange.util.OfyService.ofy;
-import static org.karmaexchange.util.UserService.getCurrentUserKey;
+import static org.karmaexchange.util.UserService.isCurrentUserAdmin;
 
 import java.util.List;
 
@@ -22,7 +21,6 @@ import com.googlecode.objectify.Objectify;
 import com.googlecode.objectify.VoidWork;
 import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Parent;
-import com.googlecode.objectify.cmd.Query;
 
 @Data
 public abstract class BaseDao<T extends BaseDao<T>> {
@@ -118,14 +116,6 @@ public abstract class BaseDao<T extends BaseDao<T>> {
     }
   }
 
-  public static <T extends BaseDao<T>> T loadFirst(Query<T> query) {
-    T resource = query.first().now();
-    if (resource != null) {
-      resource.processLoad();
-    }
-    return resource;
-  }
-
   public static <T extends BaseDao<T>> void delete(Key<T> key) {
     ofy().transact(new DeleteTxn<T>(key));
   }
@@ -208,7 +198,7 @@ public abstract class BaseDao<T extends BaseDao<T>> {
   }
 
   private final void updatePermissionWithAdminCheck() {
-    if (isAdminKey(getCurrentUserKey())) {
+    if (isCurrentUserAdmin()) {
       permission = Permission.ALL;
     } else {
       updatePermission();

--- a/src/main/java/org/karmaexchange/dao/Event.java
+++ b/src/main/java/org/karmaexchange/dao/Event.java
@@ -561,7 +561,7 @@ public final class Event extends IdBaseDao<Event> {
       }
       Key<Review> expReviewKey = Review.getKey(eventKey);
       if (review != null) {
-        review.preUpsertInit(eventKey);
+        review.initPreUpsert(eventKey);
         if (!Key.create(review).equals(expReviewKey)) {
           throw ErrorResponseMsg.createException(
             format("review key [%s] does not match expected review key [%s]",

--- a/src/main/java/org/karmaexchange/dao/OAuthCredential.java
+++ b/src/main/java/org/karmaexchange/dao/OAuthCredential.java
@@ -16,7 +16,6 @@ public class OAuthCredential {
   @Getter
   private String token;
 
-  @Index
   @Getter
   private String globalUid;
   @Index

--- a/src/main/java/org/karmaexchange/dao/Review.java
+++ b/src/main/java/org/karmaexchange/dao/Review.java
@@ -29,11 +29,7 @@ public class Review extends NameBaseDao<Review> {
   // At this point reviews will have no comments associated with them. Instead comments will
   // be associate with events and organization comments on facebook.
 
-  public void preUpsertInit(Key<?> owner) {
-    if (rating == null) {
-      throw ErrorResponseMsg.createException(
-        "a rating must be specified", ErrorInfo.Type.BAD_REQUEST);
-    }
+  public void initPreUpsert(Key<?> owner) {
     if (name == null) {
       name = getCurrentUserKey().getString();
       this.owner = owner;
@@ -43,18 +39,26 @@ public class Review extends NameBaseDao<Review> {
   @Override
   protected void preProcessInsert() {
     super.preProcessInsert();
-    validateAuthorMatches();
+    validateReview();
   }
 
   @Override
   protected void processUpdate(Review prevObj) {
     super.processUpdate(prevObj);
-    validateAuthorMatches();
+    validateReview();
   }
 
   @Override
   protected void processDelete() {
     super.processDelete();
+    validateAuthorMatches();
+  }
+
+  private void validateReview() {
+    if (rating == null) {
+      throw ErrorResponseMsg.createException(
+        "a rating must be specified", ErrorInfo.Type.BAD_REQUEST);
+    }
     validateAuthorMatches();
   }
 

--- a/src/main/java/org/karmaexchange/provider/FacebookSocialNetworkProvider.java
+++ b/src/main/java/org/karmaexchange/provider/FacebookSocialNetworkProvider.java
@@ -63,11 +63,11 @@ public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
   }
 
   @Override
-  public User initUser() {
+  public User createUser() {
     DefaultFacebookClient fbClient = new DefaultFacebookClient(credential.getToken());
     com.restfb.types.User fbUser;
     fbUser = fbClient.fetchObject("me", com.restfb.types.User.class);
-    User user = new User();
+    User user = User.create(credential);
     user.setModificationInfo(ModificationInfo.create());
     user.setFirstName(fbUser.getFirstName());
     user.setLastName(fbUser.getLastName());
@@ -85,7 +85,6 @@ public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
     //   contactInfo.setAddress(initAddress(fbClient, fbLocationKey));
     // }
 
-    user.setOauthCredentials(Lists.newArrayList(credential));
     return user;
   }
 

--- a/src/main/java/org/karmaexchange/provider/SocialNetworkProvider.java
+++ b/src/main/java/org/karmaexchange/provider/SocialNetworkProvider.java
@@ -31,7 +31,7 @@ public abstract class SocialNetworkProvider {
 
   public abstract boolean verifyCredential();
 
-  public abstract User initUser();
+  public abstract User createUser();
 
   public abstract String getProfileImageUrl();
 }

--- a/src/main/java/org/karmaexchange/resources/BaseDaoResource.java
+++ b/src/main/java/org/karmaexchange/resources/BaseDaoResource.java
@@ -46,6 +46,7 @@ public abstract class BaseDaoResource<T extends BaseDao<T>> {
   @POST
   @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
   public Response upsertResource(T resource) {
+    preProcessUpsert(resource);
     BaseDao.upsert(resource);
     URI uri = uriInfo.getAbsolutePathBuilder().path(resource.getKey()).build();
     return Response.created(uri).build();
@@ -71,6 +72,7 @@ public abstract class BaseDaoResource<T extends BaseDao<T>> {
   @POST
   @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
   public Response updateResource(@PathParam("resource") String key, T resource) {
+    preProcessUpsert(resource);
     if (resource.isKeyComplete() && !key.equals(Key.create(resource).getString())) {
       throw ErrorResponseMsg.createException(
         format("the resource key [%s] does not match the url path key [%s]",
@@ -88,4 +90,8 @@ public abstract class BaseDaoResource<T extends BaseDao<T>> {
   }
 
   protected abstract Class<T> getResourceClass();
+
+  protected void preProcessUpsert(T resource) {
+    // No-op.
+  }
 }

--- a/src/main/java/org/karmaexchange/resources/MeResource.java
+++ b/src/main/java/org/karmaexchange/resources/MeResource.java
@@ -47,13 +47,16 @@ public class MeResource {
 
   @GET
   @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-  public Response getResource() {
-    return Response.ok(getCurrentUser()).build();
+  public User getResource() {
+    return getCurrentUser();
   }
 
   @POST
   @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
   public Response updateResource(User updatedUser) {
+    if (!updatedUser.isKeyComplete()) {
+      updatedUser.initKey();
+    }
     if (!getCurrentUserKey().getString().equals(updatedUser.getKey())) {
       throw ErrorResponseMsg.createException(
         format("thew new resource key [%s] does not match the previous key [%s]",

--- a/src/main/java/org/karmaexchange/resources/UserResource.java
+++ b/src/main/java/org/karmaexchange/resources/UserResource.java
@@ -23,4 +23,11 @@ public class UserResource extends BaseDaoResource<User> {
   protected Class<User> getResourceClass() {
     return User.class;
   }
+
+  @Override
+  protected void preProcessUpsert(User user) {
+    if (!user.isKeyComplete()) {
+      user.initKey();
+    }
+  }
 }

--- a/src/main/java/org/karmaexchange/task/ProcessOrganizerRatingsServlet.java
+++ b/src/main/java/org/karmaexchange/task/ProcessOrganizerRatingsServlet.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.util.AdminUtil;
+import org.karmaexchange.util.UserService;
 
 import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.taskqueue.QueueFactory;
@@ -38,11 +39,11 @@ public class ProcessOrganizerRatingsServlet extends HttpServlet {
         logger.log(Level.WARNING, "unable to parse event key: " + eventKeyStr, e);
         return;
       }
-      AdminUtil.setUserService(AdminUtil.AdminTaskType.TASK_QUEUE);
+      AdminUtil.setCurrentUser(AdminUtil.AdminTaskType.TASK_QUEUE);
       try {
         Event.processDerivedOrganizerRatings(eventKey);
       } finally {
-        AdminUtil.clearUserService();
+        UserService.clearCurrentUser();
       }
     }
   }

--- a/src/main/java/org/karmaexchange/util/AdminUtil.java
+++ b/src/main/java/org/karmaexchange/util/AdminUtil.java
@@ -12,6 +12,12 @@ public class AdminUtil {
   private static final String ADMIN_KEY_PREFIX = "ADMIN:";
 
   public enum AdminTaskType {
+    OAUTH_FILTER {
+      @Override
+      public Key<User> getKey() {
+        return createAdminKey(name());
+      }
+    },
     TASK_QUEUE {
       @Override
       public Key<User> getKey() {
@@ -37,11 +43,7 @@ public class AdminUtil {
     return adminKeys.contains(key);
   }
 
-  public static void setUserService(AdminTaskType type) {
-    UserService.updateCurrentUser(null, type.getKey());
-  }
-
-  public static void clearUserService() {
-    UserService.updateCurrentUser(null, null);
+  public static void setCurrentUser(AdminTaskType type) {
+    UserService.setCurrentUser(null, type.getKey());
   }
 }

--- a/src/main/java/org/karmaexchange/util/UserService.java
+++ b/src/main/java/org/karmaexchange/util/UserService.java
@@ -1,6 +1,6 @@
 package org.karmaexchange.util;
 
-import javax.annotation.Nullable;
+import static org.karmaexchange.util.AdminUtil.isAdminKey;
 
 import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.OAuthCredential;
@@ -27,13 +27,19 @@ public final class UserService {
     return currentUserCredential.get();
   }
 
-  public static void updateCurrentUser(@Nullable OAuthCredential credential,
-                                       @Nullable Key<User> user) {
+  public static void setCurrentUser(OAuthCredential credential, Key<User> user) {
     currentUserCredential.set(credential);
     currentUserKey.set(user);
   }
 
-  // boolean isUserAdmin()
+  public static void clearCurrentUser() {
+    currentUserCredential.set(null);
+    currentUserKey.set(null);
+  }
+
+  public static boolean isCurrentUserAdmin() {
+    return isAdminKey(getCurrentUserKey());
+  }
 
   // Static utility methods only.
   private UserService() {

--- a/src/test/java/org/karmaexchange/dao/OrganizationTest.java
+++ b/src/test/java/org/karmaexchange/dao/OrganizationTest.java
@@ -24,9 +24,9 @@ public class OrganizationTest extends PersistenceTestHelper {
       KeyWrapper.create(Cause.create("marriage equality"))));
 
     User u1 = new User();
-    u1.setId(Long.valueOf(1));
+    u1.setName("fake name1");
     User u2 = new User();
-    u2.setId(Long.valueOf(2));
+    u2.setName("fake name2");
     org.setAdmins(asList(
       KeyWrapper.create(u1),
       KeyWrapper.create(u2)));

--- a/src/test/java/org/karmaexchange/dao/UserTest.java
+++ b/src/test/java/org/karmaexchange/dao/UserTest.java
@@ -2,8 +2,6 @@ package org.karmaexchange.dao;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.karmaexchange.util.JsonValidationTestUtil.validateJsonConversion;
 import static org.karmaexchange.util.OfyService.ofy;
@@ -34,7 +32,7 @@ public class UserTest extends PersistenceTestHelper {
 
     // Setup user1.
     user1 = new User();
-    user1.setId(Long.valueOf(26));
+    user1.setName("fake name 1");
 
     ModificationInfo modificationInfo = new ModificationInfo();
     user1.setModificationInfo(modificationInfo);
@@ -84,7 +82,7 @@ public class UserTest extends PersistenceTestHelper {
 
     // Setup user2.
     user2 = new User();
-    user2.setId(Long.valueOf(27));
+    user2.setName("fake name 2");
     user2.setSkills(asList(
       KeyWrapper.create(Skill.create("programming")),
       KeyWrapper.create(Skill.create("marketing"))));
@@ -97,15 +95,10 @@ public class UserTest extends PersistenceTestHelper {
 
   @Test
   public void testPersistence() throws Exception {
-    User user3 = new User();
-    assertNull(user3.getId());
-    ofy().save().entity(user3).now();
-    assertNotNull(user3.getId());
-
     validatePersistence(user1);
     validatePersistence(user2);
-    User userFromDb = BaseDao.load(user1.getModificationInfo().getCreationUser().getKey());
-    assertEquals(userFromDb, user1);
+    User userFromDb = BaseDao.load(Key.create(user1));
+    assertEquals(user1, userFromDb);
 
     Skill skill = Skill.create("programming");
     Set<Key<User>> userKeys = Sets.newHashSet(
@@ -141,14 +134,6 @@ public class UserTest extends PersistenceTestHelper {
       ofy().load()
            .type(User.class)
            .filter("oauthCredentials.globalUidAndToken", "tokenuidfacebook.com")
-           .keys());
-    assertEquals(1, userKeys.size());
-    assertTrue(userKeys.contains(Key.create(user1)));
-
-    userKeys = Sets.newHashSet(
-      ofy().load()
-           .type(User.class)
-           .filter("oauthCredentials.globalUid", "uidfacebook.com")
            .keys());
     assertEquals(1, userKeys.size());
     assertTrue(userKeys.contains(Key.create(user1)));


### PR DESCRIPTION
Fix duplicate automatic user creation (caused by parallel UI requests).

The user object now has a name based key that is based on the facebook uid.

**Notes:**
1. You will have to re-create all user objects.
2. Users created using "POST api/user" must have an explicit key OR an oAuth credential with the uid, provider, and token fields inited and the provider must be "facebook". The uid and token can be anything.
3. You may occasionally see "WARNING: Optimistic concurrency failure" in the dev server output. Don't worry. That's just a warning. Objectify transparently retries on contention. The contention happens both at user creation and at credential update. This is because the UI makes parallel requests and they therefore contend with each other.
