### PR TITLE
Add event status and expose current user rating in event search results.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/BaseDao.java
+++ b/src/main/java/org/karmaexchange/dao/BaseDao.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static org.karmaexchange.util.OfyService.ofy;
 import static org.karmaexchange.util.UserService.isCurrentUserAdmin;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -110,7 +111,7 @@ public abstract class BaseDao<T extends BaseDao<T>> {
     return resources;
   }
 
-  public static <T extends BaseDao<T>> void processLoadResults(List<T> resources) {
+  public static <T extends BaseDao<T>> void processLoadResults(Collection<T> resources) {
     for (T resource : resources) {
       resource.processLoad();
     }

--- a/src/main/java/org/karmaexchange/dao/Review.java
+++ b/src/main/java/org/karmaexchange/dao/Review.java
@@ -86,6 +86,10 @@ public class Review extends NameBaseDao<Review> {
     }
   }
 
+  public static <T> Key<Review> getKey(T resource) {
+    return getKey(Key.create(resource));
+  }
+
   public static Key<Review> getKey(Key<?> owner) {
     return Key.<Review>create(owner, Review.class, getCurrentUserKey().getString());
   }

--- a/src/main/java/org/karmaexchange/provider/FacebookSocialNetworkProvider.java
+++ b/src/main/java/org/karmaexchange/provider/FacebookSocialNetworkProvider.java
@@ -7,20 +7,16 @@ import java.util.logging.Logger;
 
 import javax.servlet.Filter;
 
-import org.karmaexchange.dao.Address;
 import org.karmaexchange.dao.ContactInfo;
-import org.karmaexchange.dao.GeoPtWrapper;
 import org.karmaexchange.dao.ModificationInfo;
 import org.karmaexchange.dao.OAuthCredential;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 
-import com.google.appengine.api.datastore.GeoPt;
 import com.restfb.DefaultFacebookClient;
 import com.restfb.Parameter;
 import com.restfb.exception.FacebookException;
-import com.restfb.types.NamedFacebookType;
 
 public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
 
@@ -84,6 +80,7 @@ public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
     return String.format(PROFILE_IMAGE_URL_FMT, credential.getUid());
   }
 
+  /*
   private Address initAddress(DefaultFacebookClient fbClient, NamedFacebookType fbLocationKey) {
     Address address = new Address();
     com.restfb.types.Location fbLocation = fetchObject(
@@ -108,4 +105,5 @@ public final class FacebookSocialNetworkProvider extends SocialNetworkProvider {
       throw ErrorResponseMsg.createException(e, ErrorInfo.Type.PARTNER_SERVICE_FAILURE);
     }
   }
+  */
 }

--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -109,7 +109,7 @@ public class EventResource extends BaseDaoResource<Event> {
     paginationParams.put(SEARCH_TYPE_PARAM, searchType);
 
     return ListResponseMsg.create(
-      EventSearchView.create(searchResults),
+      EventSearchView.create(searchResults, searchType),
       PagingInfo.create(afterCursor, limit, queryIter.hasNext(), baseUri, paginationParams));
   }
 

--- a/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
@@ -1,18 +1,29 @@
 package org.karmaexchange.resources.msg;
 
+import static org.karmaexchange.util.OfyService.ofy;
+
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.Event.RegistrationInfo;
+import org.karmaexchange.dao.Event.Status;
 import org.karmaexchange.dao.Location;
 import org.karmaexchange.dao.ParticipantImage;
 import org.karmaexchange.dao.Permission;
 import org.karmaexchange.dao.AggregateRating;
+import org.karmaexchange.dao.Rating;
+import org.karmaexchange.dao.Review;
+import org.karmaexchange.resources.EventResource.EventSearchType;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.googlecode.objectify.Key;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,6 +40,7 @@ public class EventSearchView {
   private Location location;
   private Date startTime;
   private Date endTime;
+  private Status status;
   private ImageUrlView primaryImage;
   private RegistrationInfo registrationInfo;
 
@@ -39,23 +51,41 @@ public class EventSearchView {
   private int maxRegistrations;
 
   private AggregateRating rating;
+  private Rating currentUserRating;
   private int karmaPoints;
 
-  public static List<EventSearchView> create(List<Event> events) {
+  public static List<EventSearchView> create(List<Event> events, EventSearchType searchType) {
+    Map<Key<Review>, Review> reviews;
+    if (searchType == EventSearchType.PAST) {
+      reviews = loadEventReviews(events);
+    } else {
+      reviews = Maps.newHashMap();
+    }
     List<EventSearchView> searchResults = Lists.newArrayListWithCapacity(events.size());
     for (Event event : events) {
-      searchResults.add(new EventSearchView(event));
+      searchResults.add(new EventSearchView(event, reviews.get(Review.getKey(event))));
     }
     return searchResults;
   }
 
-  protected EventSearchView(Event event) {
+  private static Map<Key<Review>, Review> loadEventReviews(List<Event> events) {
+    List<Key<Review>> reviewKeys = Lists.newArrayListWithCapacity(events.size());
+    for (Event event : events) {
+      reviewKeys.add(Review.getKey(event));
+    }
+    Map<Key<Review>, Review> reviews = ofy().load().keys(reviewKeys);
+    BaseDao.processLoadResults(reviews.values());
+    return reviews;
+  }
+
+  protected EventSearchView(Event event, @Nullable Review currentUserReview) {
     key = event.getKey();
     permission = event.getPermission();
     title = event.getTitle();
     location = event.getLocation();
     startTime = event.getStartTime();
     endTime = event.getEndTime();
+    status = event.getStatus();
     if (event.getPrimaryImage() != null) {
       // PrimaryImage(ImageUrlView.create(event.getPrimaryImage()));
     }
@@ -66,5 +96,8 @@ public class EventSearchView {
     maxRegistrations = event.getMaxRegistrations();
     registrationInfo = event.getRegistrationInfo();
     rating = event.getRating();
+    if (currentUserReview != null) {
+      currentUserRating = currentUserReview.getRating();
+    }
   }
 }

--- a/src/main/java/org/karmaexchange/resources/msg/ExpandedEventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ExpandedEventSearchView.java
@@ -2,6 +2,7 @@ package org.karmaexchange.resources.msg;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.karmaexchange.dao.BaseDao;
@@ -9,6 +10,7 @@ import org.karmaexchange.dao.CauseType;
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.KeyWrapper;
 import org.karmaexchange.dao.Organization;
+import org.karmaexchange.dao.Review;
 import org.karmaexchange.dao.User;
 
 import com.google.common.collect.Lists;
@@ -35,11 +37,12 @@ public class ExpandedEventSearchView extends EventSearchView {
   private List<KeyWrapper<Organization>> organizations = Lists.newArrayList();
 
   public static ExpandedEventSearchView create(Event event) {
-    return new ExpandedEventSearchView(event);
+    Review review = BaseDao.load(Review.getKey(event));
+    return new ExpandedEventSearchView(event, review);
   }
 
-  private ExpandedEventSearchView(Event event) {
-    super(event);
+  private ExpandedEventSearchView(Event event, @Nullable Review currentUserReview) {
+    super(event, currentUserReview);
     description = event.getDescription();
 
     User user = BaseDao.load(KeyWrapper.toKey(event.getOrganizers().get(0)));

--- a/src/test/java/org/karmaexchange/resources/EventResourceTest.java
+++ b/src/test/java/org/karmaexchange/resources/EventResourceTest.java
@@ -1,9 +1,5 @@
 package org.karmaexchange.resources;
 
-import static org.junit.Assert.*;
-
-import javax.ws.rs.core.MediaType;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,7 +7,6 @@ import org.karmaexchange.util.OfyService;
 
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.test.framework.JerseyTest;
 
 /*


### PR DESCRIPTION
1. Expose event status. Avoids dealing with client notion of time.
   
   public enum Status {
     UPCOMING,
     IN_PROGRESS,
     COMPLETED
   }
   
   Also, now only events that have status COMPLETED may now be reviewed.
2. For past events, the event search cruds now show the current user rating for the event.
   For the event crud itself an explicit call to /api/event/&lt;id&gt;/review has to be made.
