### PR TITLE
Add support for review comments.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/BaseDao.java
+++ b/src/main/java/org/karmaexchange/dao/BaseDao.java
@@ -90,11 +90,12 @@ public abstract class BaseDao<T extends BaseDao<T>> {
     return resource;
   }
 
-  public static <T extends BaseDao<T>> List<T> load(List<Key<T>> keys) {
+  public static <T extends BaseDao<T>> List<T> load(Collection<Key<T>> keys) {
     return load(keys, false);
   }
 
-  public static <T extends BaseDao<T>> List<T> load(List<Key<T>> keys, boolean transactionless) {
+  public static <T extends BaseDao<T>> List<T> load(Collection<Key<T>> keys,
+      boolean transactionless) {
     Objectify ofyService = transactionless ? ofy().transactionless() : ofy();
     List<T> resources = Lists.newArrayList(ofyService.load().keys(keys).values());
     for (T resource : resources) {

--- a/src/main/java/org/karmaexchange/resources/msg/EventParticipantView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventParticipantView.java
@@ -1,6 +1,8 @@
 package org.karmaexchange.resources.msg;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -10,6 +12,7 @@ import org.karmaexchange.dao.AggregateRating;
 import org.karmaexchange.dao.User;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.googlecode.objectify.Key;
 
 import lombok.Data;
@@ -34,6 +37,16 @@ public class EventParticipantView {
       }
     }
     return registeredUsers;
+  }
+
+  public static Map<Key<User>, EventParticipantView> getMap(Collection<Key<User>> usersBatch) {
+    Map<Key<User>, EventParticipantView> result = Maps.newHashMap();
+    if (!usersBatch.isEmpty()) {
+      for (User user : BaseDao.load(usersBatch)) {
+        result.put(Key.create(user), EventParticipantView.create(user));
+      }
+    }
+    return result;
   }
 
   public static EventParticipantView create(User user) {

--- a/src/main/java/org/karmaexchange/resources/msg/ListResponseMsg.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ListResponseMsg.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @XmlRootElement
 @Data
 @NoArgsConstructor
-@XmlSeeAlso({EventParticipantView.class, EventSearchView.class})
+@XmlSeeAlso({EventParticipantView.class, EventSearchView.class, ReviewCommentView.class})
 public class ListResponseMsg<T> {
 
   private List<T> data;

--- a/src/main/java/org/karmaexchange/resources/msg/ReviewCommentView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ReviewCommentView.java
@@ -1,0 +1,64 @@
+package org.karmaexchange.resources.msg;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.karmaexchange.dao.Rating;
+import org.karmaexchange.dao.Review;
+import org.karmaexchange.dao.User;
+
+import com.google.common.collect.Lists;
+import com.googlecode.objectify.Key;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@XmlRootElement
+@Data
+@NoArgsConstructor
+public final class ReviewCommentView {
+
+  private Rating rating;
+  private Date commentCreationDate;
+  private String comment;
+  private EventParticipantView authorInfo;
+
+  public static List<ReviewCommentView> create(List<Review> reviews) {
+    removeReviewsWithoutComments(reviews);
+    Map<Key<User>, EventParticipantView> authorInfo = loadAuthorInfo(reviews);
+    List<ReviewCommentView> result = Lists.newArrayList();
+    for (Review review : reviews) {
+      result.add(new ReviewCommentView(review, authorInfo.get(review.getAuthor())));
+    }
+    return result;
+  }
+
+  private static void removeReviewsWithoutComments(List<Review> reviews) {
+    Iterator<Review> reviewIter = reviews.iterator();
+    while (reviewIter.hasNext()) {
+      Review review = reviewIter.next();
+      if (review.getComment() == null) {
+        reviewIter.remove();
+      }
+    }
+  }
+
+  private static Map<Key<User>, EventParticipantView> loadAuthorInfo(List<Review> reviews) {
+    List<Key<User>> reviewAuthors = Lists.newArrayList();
+    for (Review review : reviews) {
+      reviewAuthors.add(review.getAuthor());
+    }
+    return EventParticipantView.getMap(reviewAuthors);
+  }
+
+  private ReviewCommentView(Review review, EventParticipantView authorInfo) {
+    rating = review.getRating();
+    commentCreationDate = review.getCommentCreationDate();
+    comment = review.getComment();
+    this.authorInfo = authorInfo;
+  }
+}


### PR DESCRIPTION
[1] 

The review object now supports comments. The comment is optional.

**POST /api/event/&lt;key&gt;/review**

``` json
{"rating":{"value":3.5}, "comment":"a review comment"}
```

[2] 

For all users that specified review comments, there is a JSON api to fetch those comments along with the name of the user, etc.

**GET /api/event/&lt;key&gt;/review_comment_view?limit=N**
- supports pagination
- ordered by comment creation date.
- only reviews with comments are shown.

``` xml
<listResponseMsg>
  <data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="reviewCommentView">
    <authorInfo>
      <eventOrganizerRating>
        <count>0</count>
        <sum>0.0</sum>
      </eventOrganizerRating>
      <firstName>Susan</firstName>
      <karmaPoints>0</karmaPoints>
      <key>aglrYXJtYWRlbW9yIQsSBFVzZXIiFzEwMDAwNjA3NDM3Njk1N2ZhY2Vib29rDA</key>
      <lastName>Liangberg</lastName>
      <profileImage>
        <url>https://graph.facebook.com/100006074376957/picture</url>
        <urlProvider>FACEBOOK</urlProvider>
      </profileImage>
    </authorInfo>
    <comment>second review comment (v2)!</comment>
    <commentCreationDate>2013-06-10T14:32:02.382-07:00</commentCreationDate>
    <rating>
      <value>2.0</value>
    </rating>
  </data>
</listResponseMsg>
```

Future note:

Right now we don't support anonymous comments. We could support anonymous comments in the future... however if there aren't many people who are reviewing it'll be pretty easy to figure out who said what. I think if someone wants to leave a public comment they should be willing to put their name on it. That's the google+/zagat review philosophy.
