### PR TITLE
Causes now contain a PageRef instead of an ImageRef.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/CauseType.java
+++ b/src/main/java/org/karmaexchange/dao/CauseType.java
@@ -17,7 +17,7 @@ import com.googlecode.objectify.annotation.Entity;
 @ToString(callSuper=true)
 public class CauseType extends NameBaseDao<CauseType> {
 
-  private ImageRef image;
+  private PageRef page;
 
   public static CauseType create(String name) {
     return new CauseType(name);

--- a/src/main/java/org/karmaexchange/dao/PageRef.java
+++ b/src/main/java/org/karmaexchange/dao/PageRef.java
@@ -1,0 +1,19 @@
+package org.karmaexchange.dao;
+
+import lombok.Data;
+
+import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
+
+import com.googlecode.objectify.annotation.Embed;
+
+/**
+ * This class provides a reference to a social network provider page.
+ *
+ * @author Amir Valiani (first.last@gmail.com)
+ */
+@Data
+@Embed
+public class PageRef {
+  private String url;
+  private SocialNetworkProviderType urlProvider;
+}


### PR DESCRIPTION
Causes now contain a PageRef instead of an ImageRef.

Fixes #49 

**POST /api/cause_type**
- creates a new cause / updates an existing one

``` json
{"name":"homelessness", "page":{"url":"https://www.facebook.com/109613735724487","urlProvider":"FACEBOOK"}}
```

Example source:
https://www.facebook.com/pages/Homelessness/109613735724487

Example usage:
- https://www.facebook.com/109613735724487 - is a link to the page
- GET /109613735724487/picture - gets the primary image
