### PR TITLE
Filter events for users by participant type.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/Event.java
+++ b/src/main/java/org/karmaexchange/dao/Event.java
@@ -78,7 +78,7 @@ public final class Event extends IdBaseDao<Event> {
   // Organizers can also edit the event.
 
   // Can not be explicitly set. Automatically managed.
-  @Ignore
+  @Index
   private List<KeyWrapper<User>> organizers = Lists.newArrayList();
 
   // Can not be explicitly set. Automatically managed.
@@ -91,10 +91,10 @@ public final class Event extends IdBaseDao<Event> {
   private int maxWaitingList;
 
   // Can not be explicitly set. Automatically managed.
-  @Ignore
+  @Index
   private List<KeyWrapper<User>> registeredUsers = Lists.newArrayList();
   // Can not be explicitly set. Automatically managed.
-  @Ignore
+  @Index
   private List<KeyWrapper<User>> waitListedUsers = Lists.newArrayList();
 
   // We need a consolidated list because pagination does not support OR queries.
@@ -156,6 +156,22 @@ public final class Event extends IdBaseDao<Event> {
   }
   public void setRegistrationInfo(RegistrationInfo ignored) {
     // No-op it.
+  }
+
+  public static String getParticipantPropertyName() {
+    return "participants.user.key";
+  }
+
+  public static String getParticipantPropertyName(ParticipantType type) {
+    switch (type) {
+      case ORGANIZER:
+        return "organizers.key";
+      case REGISTERED:
+        return "registeredUsers.key";
+      case WAIT_LISTED:
+        return "waitListedUsers.key";
+    }
+    throw new IllegalStateException("Unknown participant type: " + type);
   }
 
   @Override

--- a/src/main/java/org/karmaexchange/resources/MeResource.java
+++ b/src/main/java/org/karmaexchange/resources/MeResource.java
@@ -5,8 +5,6 @@ import static org.karmaexchange.resources.BaseDaoResource.DEFAULT_NUM_SEARCH_RES
 import static org.karmaexchange.util.UserService.getCurrentUser;
 import static org.karmaexchange.util.UserService.getCurrentUserKey;
 
-import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -24,6 +22,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.User;
+import org.karmaexchange.dao.Event.ParticipantType;
 import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
 import org.karmaexchange.resources.EventResource.EventSearchType;
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
@@ -35,7 +34,6 @@ import org.karmaexchange.util.ImageUploadUtil;
 
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
-import com.google.common.collect.Maps;
 
 @Path("/me")
 public class MeResource {
@@ -79,11 +77,10 @@ public class MeResource {
       @QueryParam(EventResource.SEARCH_TYPE_PARAM) EventSearchType searchType,
       @QueryParam(PagingInfo.AFTER_CURSOR_PARAM) String afterCursorStr,
       @QueryParam(PagingInfo.LIMIT_PARAM) @DefaultValue(DEFAULT_NUM_SEARCH_RESULTS) int limit,
-      @QueryParam(EventResource.START_TIME_PARAM) Long startTimeValue) {
-    Map<String, Object> filters = Maps.newHashMap();
-    filters.put("participants.user.key", getCurrentUserKey());
-    return EventResource.eventSearch(afterCursorStr, limit, startTimeValue,
-      uriInfo.getAbsolutePath(), searchType, filters);
+      @QueryParam(EventResource.START_TIME_PARAM) Long startTimeValue,
+      @QueryParam(EventResource.PARTICIPANT_TYPE_PARAM) ParticipantType participantType) {
+    return UserResource.userEventSearch(uriInfo, getCurrentUserKey(), searchType, afterCursorStr,
+      limit, startTimeValue, participantType);
   }
 
   @Path("profile_image")

--- a/src/main/java/org/karmaexchange/resources/UserResource.java
+++ b/src/main/java/org/karmaexchange/resources/UserResource.java
@@ -1,8 +1,8 @@
 package org.karmaexchange.resources;
 
 import java.util.List;
-import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -10,25 +10,24 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 
 import org.karmaexchange.dao.BaseDao;
+import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.User;
+import org.karmaexchange.dao.Event.ParticipantType;
 import org.karmaexchange.resources.EventResource.EventSearchType;
 import org.karmaexchange.resources.msg.EventSearchView;
 import org.karmaexchange.resources.msg.ListResponseMsg;
 import org.karmaexchange.resources.msg.ListResponseMsg.PagingInfo;
+import org.karmaexchange.util.PaginationParam;
+import org.karmaexchange.util.PaginatedQuery.FilterQueryClause;
 
-import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
 import com.googlecode.objectify.Key;
 
 @Path("/user")
 public class UserResource extends BaseDaoResource<User> {
-
-  @GET
-  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-  public List<User> getResources() {
-    return BaseDao.loadAll(getResourceClass());
-  }
 
   @Override
   protected Class<User> getResourceClass() {
@@ -42,6 +41,12 @@ public class UserResource extends BaseDaoResource<User> {
     }
   }
 
+  @GET
+  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  public List<User> getResources() {
+    return BaseDao.loadAll(getResourceClass());
+  }
+
   @Path("{user_key}/event")
   @GET
   @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
@@ -50,10 +55,25 @@ public class UserResource extends BaseDaoResource<User> {
       @QueryParam(EventResource.SEARCH_TYPE_PARAM) EventSearchType searchType,
       @QueryParam(PagingInfo.AFTER_CURSOR_PARAM) String afterCursorStr,
       @QueryParam(PagingInfo.LIMIT_PARAM) @DefaultValue(DEFAULT_NUM_SEARCH_RESULTS) int limit,
-      @QueryParam(EventResource.START_TIME_PARAM) Long startTimeValue) {
-    Map<String, Object> filters = Maps.newHashMap();
-    filters.put("participants.user.key", Key.<User>create(userKeyStr));
+      @QueryParam(EventResource.START_TIME_PARAM) Long startTimeValue,
+      @QueryParam(EventResource.PARTICIPANT_TYPE_PARAM) ParticipantType participantType) {
+    return userEventSearch(uriInfo, Key.<User>create(userKeyStr), searchType, afterCursorStr,
+      limit, startTimeValue, participantType);
+  }
+
+  public static ListResponseMsg<EventSearchView> userEventSearch(UriInfo uriInfo, Key<User> userKey,
+      @Nullable EventSearchType searchType, @Nullable String afterCursorStr, int limit,
+      @Nullable Long startTimeValue, @Nullable ParticipantType participantType) {
+    FilterQueryClause participantFilter;
+    if (participantType == null) {
+      participantFilter = new FilterQueryClause(Event.getParticipantPropertyName(), userKey);
+    } else {
+      participantFilter =
+          new FilterQueryClause(Event.getParticipantPropertyName(participantType), userKey);
+      participantFilter.setPaginationParam(
+        new PaginationParam(EventResource.PARTICIPANT_TYPE_PARAM, participantType.toString()));
+    }
     return EventResource.eventSearch(afterCursorStr, limit, startTimeValue,
-      uriInfo.getAbsolutePath(), searchType, filters);
+      uriInfo.getAbsolutePath(), searchType, Lists.newArrayList(participantFilter));
   }
 }

--- a/src/main/java/org/karmaexchange/util/PaginatedQuery.java
+++ b/src/main/java/org/karmaexchange/util/PaginatedQuery.java
@@ -1,0 +1,185 @@
+package org.karmaexchange.util;
+
+import static org.karmaexchange.util.OfyService.ofy;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.appengine.api.datastore.Cursor;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.googlecode.objectify.cmd.Query;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Data
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaginatedQuery<T> {
+
+  private final Class<T> resourceClass;
+  private final Collection<QueryClause> queryClauses;
+
+  public Query<T> getOfyQuery() {
+    Query<T> query = ofy().load().type(resourceClass);
+    for (QueryClause queryClause : queryClauses) {
+      query = queryClause.apply(query);
+    }
+    return query;
+  }
+
+  public Map<String, Object> getPaginationParams() {
+    Map<String, Object> paginationParams = Maps.newHashMap();
+    for (QueryClause queryClause : queryClauses) {
+      PaginationParam param = queryClause.getPaginationParam();
+      if (param != null) {
+        paginationParams.put(param.getName(), param.getValue());
+      }
+    }
+    return paginationParams;
+  }
+
+  @Data
+  public static class Builder<T> {
+    private final Class<T> resourceClass;
+    private List<FilterQueryClause> queryFilters = Lists.newArrayList();
+    @Nullable
+    private AncestorQueryClause ancestorFilter;
+    @Nullable
+    private OrderQueryClause order;
+    @Nullable
+    private Integer limit;
+    @Nullable
+    private Cursor afterCursor;
+
+    public static <T> Builder<T> create(Class<T> resourceClass) {
+      return new Builder<T>(resourceClass);
+    }
+
+    private Builder(Class<T> resourceClass) {
+      this.resourceClass = resourceClass;
+    }
+
+    public Builder<T> addFilter(FilterQueryClause filter) {
+      queryFilters.add(filter);
+      return this;
+    }
+
+    public Builder<T> addFilters(Collection<? extends FilterQueryClause> filters) {
+      queryFilters.addAll(filters);
+      return this;
+    }
+
+    public Builder<T> setAncestorFilter(@Nullable AncestorQueryClause ancestorFilter) {
+      this.ancestorFilter = ancestorFilter;
+      return this;
+    }
+
+    public Builder<T> setOrder(@Nullable OrderQueryClause order) {
+      this.order = order;
+      return this;
+    }
+
+    public Builder<T> setLimit(@Nullable Integer limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder<T> setAfterCursor(@Nullable Cursor afterCursor) {
+      this.afterCursor = afterCursor;
+      return this;
+    }
+
+    public PaginatedQuery<T> build() {
+      List<QueryClause> queryClauses = Lists.newArrayList();
+      queryClauses.addAll(queryFilters);
+      if (ancestorFilter != null) {
+        queryClauses.add(ancestorFilter);
+      }
+      if (order != null) {
+        queryClauses.add(order);
+      }
+      if (limit != null) {
+        queryClauses.add(new LimitQueryClause(limit));
+      }
+      if (afterCursor != null) {
+        queryClauses.add(new StartAtQueryClause(afterCursor));
+      }
+      return new PaginatedQuery<T>(resourceClass, queryClauses);
+    }
+  }
+
+  @Data
+  public static abstract class QueryClause {
+    protected PaginationParam paginationParam;
+
+    public abstract <T> Query<T> apply(Query<T> query);
+  }
+
+  @Data
+  @EqualsAndHashCode(callSuper=true)
+  @ToString(callSuper=true)
+  public static class FilterQueryClause extends QueryClause {
+
+    private final String condition;
+    private final Object value;
+
+    public <T> Query<T> apply(Query<T> query) {
+      return query.filter(condition, value);
+    }
+  }
+
+  @Data
+  @EqualsAndHashCode(callSuper=true)
+  @ToString(callSuper=true)
+  public static class AncestorQueryClause extends QueryClause {
+
+    private final Object ancestor;
+
+    public <T> Query<T> apply(Query<T> query) {
+      return query.ancestor(ancestor);
+    }
+  }
+
+  @Data
+  @EqualsAndHashCode(callSuper=true)
+  @ToString(callSuper=true)
+  public static class OrderQueryClause extends QueryClause {
+
+    private final String order;
+
+    public <T> Query<T> apply(Query<T> query) {
+      return query.order(order);
+    }
+  }
+
+  @Data
+  @EqualsAndHashCode(callSuper=true)
+  @ToString(callSuper=true)
+  private static class LimitQueryClause extends QueryClause {
+
+    private final int limit;
+
+    public <T> Query<T> apply(Query<T> query) {
+      return query.limit(limit);
+    }
+  }
+
+  @Data
+  @EqualsAndHashCode(callSuper=true)
+  @ToString(callSuper=true)
+  private static class StartAtQueryClause extends QueryClause {
+
+    private final Cursor afterCursor;
+
+    public <T> Query<T> apply(Query<T> query) {
+      return query.startAt(afterCursor);
+    }
+  }
+}

--- a/src/main/java/org/karmaexchange/util/PaginationParam.java
+++ b/src/main/java/org/karmaexchange/util/PaginationParam.java
@@ -1,0 +1,9 @@
+package org.karmaexchange.util;
+
+import lombok.Data;
+
+@Data
+public class PaginationParam {
+  private final String name;
+  private final String value;
+}


### PR DESCRIPTION
Events returned for a user can now be filtered by participant_type. JSON api doc will be updated after the pull request is merged.

Example:
http://localhost:8080/api/me/event?participant_type=ORGANIZER
or
http://localhost:8080/api/user/{user_key}/event?participant_type=ORGANIZER

**Datastore implications:**
Requires re-creating events or editing all events (which forces indexing of all properties). The newly indexed fields in the event object will not be available for searching otherwise.
