### PR TITLE
Conditionally load current user rating in past event search.

### DIFF
--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -77,12 +77,12 @@ public class EventResource extends BaseDaoResource<Event> {
       @QueryParam(PagingInfo.LIMIT_PARAM) @DefaultValue(DEFAULT_NUM_SEARCH_RESULTS) int limit,
       @QueryParam(START_TIME_PARAM) Long startTimeValue) {
     return eventSearch(afterCursorStr, limit, startTimeValue, uriInfo.getAbsolutePath(),
-      searchType, ImmutableList.<FilterQueryClause>of());
+      searchType, ImmutableList.<FilterQueryClause>of(), true);
   }
 
   public static ListResponseMsg<EventSearchView> eventSearch(String afterCursorStr, int limit,
       Long startTimeValue, URI baseUri, EventSearchType searchType,
-      Collection<? extends FilterQueryClause> filters) {
+      Collection<? extends FilterQueryClause> filters, boolean loadReviews) {
     PaginatedQuery.Builder<Event> queryBuilder = PaginatedQuery.Builder.create(Event.class)
         .addFilters(filters);
     if (afterCursorStr != null) {
@@ -106,7 +106,7 @@ public class EventResource extends BaseDaoResource<Event> {
     BaseDao.processLoadResults(searchResults);
 
     return ListResponseMsg.create(
-      EventSearchView.create(searchResults, searchType),
+      EventSearchView.create(searchResults, searchType, loadReviews),
       PagingInfo.create(afterCursor, limit, queryIter.hasNext(), baseUri,
         paginatedQuery.getPaginationParams()));
   }

--- a/src/main/java/org/karmaexchange/resources/UserResource.java
+++ b/src/main/java/org/karmaexchange/resources/UserResource.java
@@ -1,5 +1,7 @@
 package org.karmaexchange.resources;
 
+import static org.karmaexchange.util.UserService.getCurrentUserKey;
+
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -65,6 +67,7 @@ public class UserResource extends BaseDaoResource<User> {
       @Nullable EventSearchType searchType, @Nullable String afterCursorStr, int limit,
       @Nullable Long startTimeValue, @Nullable ParticipantType participantType) {
     FilterQueryClause participantFilter;
+    boolean loadReviews = userKey.equals(getCurrentUserKey());
     if (participantType == null) {
       participantFilter = new FilterQueryClause(Event.getParticipantPropertyName(), userKey);
     } else {
@@ -74,6 +77,6 @@ public class UserResource extends BaseDaoResource<User> {
         new PaginationParam(EventResource.PARTICIPANT_TYPE_PARAM, participantType.toString()));
     }
     return EventResource.eventSearch(afterCursorStr, limit, startTimeValue,
-      uriInfo.getAbsolutePath(), searchType, Lists.newArrayList(participantFilter));
+      uriInfo.getAbsolutePath(), searchType, Lists.newArrayList(participantFilter), loadReviews);
   }
 }

--- a/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
@@ -54,9 +54,10 @@ public class EventSearchView {
   private Rating currentUserRating;
   private int karmaPoints;
 
-  public static List<EventSearchView> create(List<Event> events, EventSearchType searchType) {
+  public static List<EventSearchView> create(List<Event> events, EventSearchType searchType,
+      boolean loadReviews) {
     Map<Key<Review>, Review> reviews;
-    if (searchType == EventSearchType.PAST) {
+    if (loadReviews && (searchType == EventSearchType.PAST)) {
       reviews = loadEventReviews(events);
     } else {
       reviews = Maps.newHashMap();


### PR DESCRIPTION
Previously if you were looking at the past events for another user you would see currentUserRating filled in if you had specified a rating. This was wasteful. That has now been eliminated.
