### PR TITLE
Add event keyword search.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+            <version>4.3.0</version>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
+++ b/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
@@ -31,6 +31,8 @@ import com.googlecode.objectify.Key;
 
 public class TestResourcesBootstrapTask extends BootstrapTask {
 
+  private static int eventNum = 0;
+
   public enum TestUser {
     USER1("100006074376957", "Susan", "Liangberg"),
     USER2("100006058506752", "John", "Occhinostein"),
@@ -172,13 +174,20 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
       List<Key<User>> organizers, List<Key<User>> registeredUsers,
       List<Key<User>> waitListedUsers, int minRegistrations, int maxRegistrations,
       int maxWaitingList) {
+    eventNum++;
     Event event = new Event();
     event.setTitle(title);
-    event.setDescription("The Eastmont Garden of Hope receives and distributes donated clothing, hygiene products, household items, canned goods, and other necessities to Social Services Agency clients in urgent need year-round. This program serves as many as 400 households monthly. Whether providing food for a struggling family, a warm coat for a shivering child, or diapers for a desperate mother’s newborn, the Eastmont Garden of Hope seeks to ensure that those in greatest need are served expeditiously and with utmost compassion. Volunteers play a vital role in the program's operations by managing donations and keeping the service area open and available to customers in need throughout the week.\n\n" +
-        "Volunteers are requested to participate for at least one shift (3-4 hours) per week, for at least 3 months. Scheduling is flexible, Monday-Friday, between the hours of 9:00am-12:00pm and 1:00-5:00pm.");
-    event.setSpecialInstructions("A mandatory Orientation is scheduled for Saturday, June 29, 2013 from 10:00-12:00 at the San Lorenzo Public Library (community meeting room): 395 Paseo Grande, San Lorenzo. Please contact Andrea Wong, coordinator at 510-271-9163 or ssavolunteer@acgov.org to inquire about availability of this position and confirm attendance at orientation.");
-    event.setCauses(KeyWrapper.create(
-      asList(CauseType.getKey("Animals"), CauseType.getKey("Disabled"))));
+    if (eventNum % 2 == 0) {
+      event.setDescription("The Eastmont Garden of Hope receives and distributes donated clothing, hygiene products, household items, canned goods, and other necessities to Social Services Agency clients in urgent need year-round. This program serves as many as 400 households monthly. Whether providing food for a struggling family, a warm coat for a shivering child, or diapers for a desperate mother’s newborn, the Eastmont Garden of Hope seeks to ensure that those in greatest need are served expeditiously and with utmost compassion. Volunteers play a vital role in the program's operations by managing donations and keeping the service area open and available to customers in need throughout the week.\n\n" +
+          "Volunteers are requested to participate for at least one shift (3-4 hours) per week, for at least 3 months. Scheduling is flexible, Monday-Friday, between the hours of 9:00am-12:00pm and 1:00-5:00pm.");
+      event.setSpecialInstructions("A mandatory Orientation is scheduled for Saturday, June 29, 2013 from 10:00-12:00 at the San Lorenzo Public Library (community meeting room): 395 Paseo Grande, San Lorenzo. Please contact Axxxx Wxxx, coordinator at XXX-XXX-XXXX or xxx@xxx.org to inquire about availability of this position and confirm attendance at orientation.");
+      event.setCauses(KeyWrapper.create(
+        asList(CauseType.getKey("Disabled"))));
+    } else {
+      event.setDescription("We are seeking volunteers willing to provide in-home respite care for people with terminally ill companion animals. Ancillary services would involve providing some comfort care for the pets themselves as well as pet loss counseling for those who have lost a pet. Risk management and liability issues are still being explored vis-a-vis a possible partnership with our local Humane Society of the North Bay, but we hope to begin training sessions for volunteers in 2014. In the meantime, volunteers will undergo initial screening through The NHFP. Please be patient if you do not hear from us right away. We are generally inundated with requests for emergency pet hospice care as well as involved with training seminars or our biennial symposium. We would appreciate a telephone call from you if you have not heard back from us within four weeks. Please call (XXX) XXX-XXXX and/or leave a message explaining you are a potential volunteer.");
+      event.setCauses(KeyWrapper.create(
+        asList(CauseType.getKey("Animals"))));
+    }
     event.setLocation(createLocation());
     event.setStartTime(startTime);
     event.setEndTime(DateUtils.addHours(startTime, numHours));

--- a/src/main/java/org/karmaexchange/resources/MeResource.java
+++ b/src/main/java/org/karmaexchange/resources/MeResource.java
@@ -1,14 +1,12 @@
 package org.karmaexchange.resources;
 
 import static java.lang.String.format;
-import static org.karmaexchange.resources.BaseDaoResource.DEFAULT_NUM_SEARCH_RESULTS;
 import static org.karmaexchange.util.UserService.getCurrentUser;
 import static org.karmaexchange.util.UserService.getCurrentUserKey;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -22,14 +20,11 @@ import javax.ws.rs.core.UriInfo;
 
 import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.User;
-import org.karmaexchange.dao.Event.ParticipantType;
 import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
-import org.karmaexchange.resources.EventResource.EventSearchType;
 import org.karmaexchange.resources.msg.ErrorResponseMsg;
 import org.karmaexchange.resources.msg.EventSearchView;
 import org.karmaexchange.resources.msg.ListResponseMsg;
 import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
-import org.karmaexchange.resources.msg.ListResponseMsg.PagingInfo;
 import org.karmaexchange.util.ImageUploadUtil;
 
 import com.google.appengine.api.blobstore.BlobKey;
@@ -73,14 +68,8 @@ public class MeResource {
   @Path("event")
   @GET
   @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-  public ListResponseMsg<EventSearchView> getEvents(
-      @QueryParam(EventResource.SEARCH_TYPE_PARAM) EventSearchType searchType,
-      @QueryParam(PagingInfo.AFTER_CURSOR_PARAM) String afterCursorStr,
-      @QueryParam(PagingInfo.LIMIT_PARAM) @DefaultValue(DEFAULT_NUM_SEARCH_RESULTS) int limit,
-      @QueryParam(EventResource.START_TIME_PARAM) Long startTimeValue,
-      @QueryParam(EventResource.PARTICIPANT_TYPE_PARAM) ParticipantType participantType) {
-    return UserResource.userEventSearch(uriInfo, getCurrentUserKey(), searchType, afterCursorStr,
-      limit, startTimeValue, participantType);
+  public ListResponseMsg<EventSearchView> getEvents() {
+    return UserResource.userEventSearch(uriInfo, getCurrentUserKey());
   }
 
   @Path("profile_image")

--- a/src/main/java/org/karmaexchange/util/PaginatedQuery.java
+++ b/src/main/java/org/karmaexchange/util/PaginatedQuery.java
@@ -128,10 +128,19 @@ public class PaginatedQuery<T> {
   public static class FilterQueryClause extends QueryClause {
 
     private final String condition;
-    private final Object value;
+    private final Object[] values;
 
+    public FilterQueryClause(String condition, Object... values) {
+      this.condition = condition;
+      this.values = values;
+    }
+
+    @Override
     public <T> Query<T> apply(Query<T> query) {
-      return query.filter(condition, value);
+      for (Object value : values) {
+        query = query.filter(condition, value);
+      }
+      return query;
     }
   }
 
@@ -142,6 +151,7 @@ public class PaginatedQuery<T> {
 
     private final Object ancestor;
 
+    @Override
     public <T> Query<T> apply(Query<T> query) {
       return query.ancestor(ancestor);
     }
@@ -154,6 +164,7 @@ public class PaginatedQuery<T> {
 
     private final String order;
 
+    @Override
     public <T> Query<T> apply(Query<T> query) {
       return query.order(order);
     }
@@ -166,6 +177,7 @@ public class PaginatedQuery<T> {
 
     private final int limit;
 
+    @Override
     public <T> Query<T> apply(Query<T> query) {
       return query.limit(limit);
     }
@@ -178,6 +190,7 @@ public class PaginatedQuery<T> {
 
     private final Cursor afterCursor;
 
+    @Override
     public <T> Query<T> apply(Query<T> query) {
       return query.startAt(afterCursor);
     }

--- a/src/main/java/org/karmaexchange/util/SearchUtil.java
+++ b/src/main/java/org/karmaexchange/util/SearchUtil.java
@@ -1,0 +1,92 @@
+package org.karmaexchange.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Set;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.core.StopFilter;
+import org.apache.lucene.analysis.en.EnglishPossessiveFilter;
+import org.apache.lucene.analysis.en.KStemFilter;
+import org.apache.lucene.analysis.standard.StandardFilter;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.util.StopwordAnalyzerBase;
+import org.apache.lucene.util.Version;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+public class SearchUtil {
+
+  private static final Analyzer ANALYZER = new KStemEnglishAnalyzer();
+
+  public static Set<String> getSearchableTokens(String string, int maxTokens) {
+    Set<String> result = Sets.newHashSet();
+    try {
+      TokenStream tokenStream  = ANALYZER.tokenStream(null, new StringReader(string));
+      CharTermAttribute termAttr = tokenStream.addAttribute(CharTermAttribute.class);
+      try {
+        tokenStream.reset();
+        while ((result.size() < maxTokens) && tokenStream.incrementToken()) {
+          result.add(termAttr.toString());
+        }
+        tokenStream.end();
+      } finally {
+        tokenStream.close();
+      }
+    } catch (IOException e) {
+      // Should not be thrown since a string is the input.
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+
+  /**
+   * This class is a combination of the StandardAnalyzer and the EnglishAnalyzer modified to
+   * use the KStemFilter and a larger stop word list.
+   */
+  // TODO(avaliani): Consider adding a filter to handle contractions like isn't.
+  private static final class KStemEnglishAnalyzer extends StopwordAnalyzerBase {
+
+    /** Default maximum allowed token length */
+    private static final int DEFAULT_MAX_TOKEN_LENGTH = 255;
+
+    private static final Version LUCENE_VERSION = Version.LUCENE_43;
+    private static final CharArraySet STOP_WORDS;
+    static {
+      // This list is larger than the included stop word list in lucene.
+      // Source: http://www.textfixer.com/resources/common-english-words.txt
+      String stopWords = "a,able,about,across,after,all,almost,also,am,among,an,and,any,are,as,at,be,because,been,but,by,can,cannot,could,dear,did,do,does,either,else,ever,every,for,from,get,got,had,has,have,he,her,hers,him,his,how,however,i,if,in,into,is,it,its,just,least,let,like,likely,may,me,might,most,must,my,neither,no,nor,not,of,off,often,on,only,or,other,our,own,rather,said,say,says,she,should,since,so,some,than,that,the,their,them,then,there,these,they,this,tis,to,too,twas,us,wants,was,we,were,what,when,where,which,while,who,whom,why,will,with,would,yet,you,your";
+      STOP_WORDS =
+          new CharArraySet(LUCENE_VERSION, ImmutableSet.copyOf(stopWords.split(",")), true);
+    }
+
+    public KStemEnglishAnalyzer() {
+      super(LUCENE_VERSION, STOP_WORDS);
+    }
+
+    @Override
+    protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
+      final StandardTokenizer src = new StandardTokenizer(matchVersion, reader);
+      src.setMaxTokenLength(DEFAULT_MAX_TOKEN_LENGTH);
+      TokenStream result = new StandardFilter(matchVersion, src);
+      result = new EnglishPossessiveFilter(matchVersion, result);
+      result = new LowerCaseFilter(matchVersion, result);
+      result = new StopFilter(matchVersion, result, stopwords);
+      result = new KStemFilter(result);
+      // result = new PorterStemFilter(result);
+      return new TokenStreamComponents(src, result) {
+        @Override
+        protected void setReader(final Reader reader) throws IOException {
+          src.setMaxTokenLength(DEFAULT_MAX_TOKEN_LENGTH);
+          super.setReader(reader);
+        }
+      };
+    }
+  }
+}

--- a/src/test/java/org/karmaexchange/util/SearchUtilTest.java
+++ b/src/test/java/org/karmaexchange/util/SearchUtilTest.java
@@ -1,0 +1,21 @@
+package org.karmaexchange.util;
+
+import static org.junit.Assert.*;
+import static org.karmaexchange.util.SearchUtil.getSearchableTokens;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+public class SearchUtilTest {
+
+  @Test
+  public void testGetSearchTokens() {
+    assertEquals(
+      ImmutableSet.of("amir", "test", "case", "isn't", "amazing", "instructive", "bus"),
+      getSearchableTokens(
+        "Amir's test case isn't \"amazing\" but it. Is 'instructive' bus buses able " +
+        "token limit reached.", 7));
+  }
+
+}


### PR DESCRIPTION
Added event keyword search.

Closes #66 - Basic event search json api

Syntax:
- new param "keywords" that takes up to 20 keywords (arbitrary limit chosen to limit expensive queries on common words)

http://localhost:8080/api/event?keywords=ferry+building

Details:
- stop word filtering, lucene k-stem filter for stemming, lucene english-possessive filter,
  lucene standard tokenization (removes punctuation, quotes, etc.)
- all the searchable tokens are stored in the event. See field: searchableTokens
- fields that are used for search. Up to 100 words per event are indexed:
  - title
  - cause names
  - location title
  - description - until token limit is hit.

Notes: to test keyword search you have to re-create or re-edit all events. mvn clean + run /bootstrap/test_resources as usual.
