### PR TITLE
Added event completion processing.

### DIFF
--- a/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
+++ b/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
@@ -98,8 +98,13 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
       }
     }
     statusWriter.println("About to persist test events...");
+    Date now = new Date();
     for (Event event : createEvents()) {
       BaseDao.upsert(event);
+      // Process any completed events.
+      if (event.getEndTime().before(now)) {
+        Event.processEventCompletionTasks(Key.create(event));
+      }
     }
     statusWriter.println("Test users and events persisted.");
   }
@@ -142,18 +147,18 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     registeredUsers = asList(USER2.getKey(), USER4.getKey(), USER5.getKey(),
       USER6.getKey(), USER7.getKey(), USER8.getKey(), USER9.getKey(), USER10.getKey(),
       USER11.getKey(), USER12.getKey(), USER13.getKey(), AMIR.getKey());
-    waitListedUsers = asList();
+    waitListedUsers = asList(USER3.getKey());
     events.add(createEvent("Harish as Organizer, Amir participant - SF Street Cleanup",
       DateUtils.addDays(now, -6), 1,
-      organizers, registeredUsers, waitListedUsers, 0, 100, 100));
+      organizers, registeredUsers, waitListedUsers, 0, registeredUsers.size(), 100));
 
     organizers = asList(USER1.getKey(), AMIR.getKey());
     registeredUsers = asList(USER2.getKey(), USER4.getKey(), USER5.getKey(),
       USER6.getKey(), USER7.getKey(), USER8.getKey(), HARISH.getKey());
-    waitListedUsers = asList();
+    waitListedUsers = asList(USER3.getKey());
     events.add(createEvent("Amir as Organizer, Harish participant - SF Street Cleanup",
       DateUtils.addDays(now, -13), 1,
-      organizers, registeredUsers, waitListedUsers, 0, 100, 100));
+      organizers, registeredUsers, waitListedUsers, 0, registeredUsers.size(), 100));
 
     organizers = asList(USER1.getKey(), HARISH.getKey());
     registeredUsers = asList(USER2.getKey(), USER4.getKey(), USER5.getKey());

--- a/src/main/java/org/karmaexchange/dao/User.java
+++ b/src/main/java/org/karmaexchange/dao/User.java
@@ -112,6 +112,7 @@ public final class User extends NameBaseDao<User> {
     // this out.
     // profileImage = null;
     eventOrganizerRating = IndexedAggregateRating.create();
+    karmaPoints = 0;
   }
 
   @Override
@@ -124,11 +125,7 @@ public final class User extends NameBaseDao<User> {
     profileImage = oldUser.profileImage;
     eventOrganizerRating = oldUser.eventOrganizerRating;
     oauthCredentials = Lists.newArrayList(oldUser.oauthCredentials);
-
-    // TODO(avlaiani): re-evaluate this. All fields should be updateable if you have admin
-    //     privileges.
-    // setKarmaPoints(oldUser.getKarmaPoints());
-    // setEventOrganizerRating(oldUser.getEventOrganizerRating());
+    karmaPoints = oldUser.karmaPoints;
   }
 
   @Override

--- a/src/main/java/org/karmaexchange/task/AdminTaskServlet.java
+++ b/src/main/java/org/karmaexchange/task/AdminTaskServlet.java
@@ -1,0 +1,36 @@
+package org.karmaexchange.task;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.karmaexchange.util.AdminUtil;
+import org.karmaexchange.util.UserService;
+
+@SuppressWarnings("serial")
+public abstract class AdminTaskServlet extends HttpServlet {
+
+  protected HttpServletRequest req;
+  protected HttpServletResponse resp;
+
+  protected abstract void execute() throws IOException;
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    this.req = req;
+    this.resp = resp;
+    AdminUtil.setCurrentUser(AdminUtil.AdminTaskType.TASK_QUEUE);
+    try {
+      execute();
+    } finally {
+      UserService.clearCurrentUser();
+    }
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    doGet(req, resp);
+  }
+}

--- a/src/main/java/org/karmaexchange/task/DeleteBlobServlet.java
+++ b/src/main/java/org/karmaexchange/task/DeleteBlobServlet.java
@@ -4,10 +4,6 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import com.google.appengine.api.taskqueue.Queue;
@@ -15,7 +11,7 @@ import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
 
 @SuppressWarnings("serial")
-public class DeleteBlobServlet extends HttpServlet {
+public class DeleteBlobServlet extends AdminTaskServlet {
 
   private static final Logger logger = Logger.getLogger(DeleteBlobServlet.class.getName());
 
@@ -23,7 +19,7 @@ public class DeleteBlobServlet extends HttpServlet {
   private static final String BLOB_KEY_PARAM = "blob_key";
 
   @Override
-  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+  public void execute() throws IOException {
     String blobKeyStr = req.getParameter(BLOB_KEY_PARAM);
     if (blobKeyStr == null) {
       logger.warning("no blob key specified");
@@ -37,11 +33,6 @@ public class DeleteBlobServlet extends HttpServlet {
       }
       BlobstoreServiceFactory.getBlobstoreService().delete(blobKey);
     }
-  }
-
-  @Override
-  public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    doGet(req, resp);
   }
 
   public static void enqueueTask(BlobKey blobKey) {

--- a/src/main/java/org/karmaexchange/task/ProcessEventCompletionsServlet.java
+++ b/src/main/java/org/karmaexchange/task/ProcessEventCompletionsServlet.java
@@ -1,0 +1,36 @@
+package org.karmaexchange.task;
+
+import static org.karmaexchange.util.OfyService.ofy;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.karmaexchange.dao.Event;
+
+import com.googlecode.objectify.Key;
+
+/*
+ * Explicit invocation path:
+ *   /task/process_event_completions
+ */
+@SuppressWarnings("serial")
+public class ProcessEventCompletionsServlet extends AdminTaskServlet {
+
+  private static final Logger logger = Logger.getLogger(
+    ProcessOrganizerRatingsServlet.class.getName());
+
+  @Override
+  protected void execute() throws IOException {
+    Date now = new Date();
+    Iterable<Key<Event>> eventsToComplete = ofy().load().type(Event.class)
+        .filter("completionProcessed", false)
+        .filter("endTime <", now)
+        .keys();
+    for (Key<Event> eventKey : eventsToComplete) {
+      logger.log(Level.INFO, "Processing event completion: eventKey=" + eventKey.getString());
+      Event.processEventCompletionTasks(eventKey);
+    }
+  }
+}

--- a/src/main/java/org/karmaexchange/task/ProcessOrganizerRatingsServlet.java
+++ b/src/main/java/org/karmaexchange/task/ProcessOrganizerRatingsServlet.java
@@ -4,13 +4,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.karmaexchange.dao.Event;
-import org.karmaexchange.util.AdminUtil;
-import org.karmaexchange.util.UserService;
 
 import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.taskqueue.QueueFactory;
@@ -18,7 +12,7 @@ import com.google.appengine.api.taskqueue.TaskOptions;
 import com.googlecode.objectify.Key;
 
 @SuppressWarnings("serial")
-public class ProcessOrganizerRatingsServlet extends HttpServlet {
+public class ProcessOrganizerRatingsServlet extends AdminTaskServlet {
 
   private static final Logger logger = Logger.getLogger(
     ProcessOrganizerRatingsServlet.class.getName());
@@ -27,7 +21,7 @@ public class ProcessOrganizerRatingsServlet extends HttpServlet {
   private static final String EVENT_KEY_PARAM = "event_key";
 
   @Override
-  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+  protected void execute() throws IOException {
     String eventKeyStr = req.getParameter(EVENT_KEY_PARAM);
     if (eventKeyStr == null) {
       logger.warning("no event key specified");
@@ -39,18 +33,8 @@ public class ProcessOrganizerRatingsServlet extends HttpServlet {
         logger.log(Level.WARNING, "unable to parse event key: " + eventKeyStr, e);
         return;
       }
-      AdminUtil.setCurrentUser(AdminUtil.AdminTaskType.TASK_QUEUE);
-      try {
-        Event.processDerivedOrganizerRatings(eventKey);
-      } finally {
-        UserService.clearCurrentUser();
-      }
+      Event.processDerivedOrganizerRatings(eventKey);
     }
-  }
-
-  @Override
-  public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    doGet(req, resp);
   }
 
   public static void enqueueTask(Event event) {

--- a/src/main/webapp/WEB-INF/cron.xml
+++ b/src/main/webapp/WEB-INF/cron.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cronentries>
+    <cron>
+        <url>/task/process_event_completions</url>
+        <description>Process completed events</description>
+        <schedule>every 10 minutes</schedule>
+    </cron>
+</cronentries>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -51,6 +51,15 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>ProcessEventCompletionsServlet</servlet-name>
+        <servlet-class>org.karmaexchange.task.ProcessEventCompletionsServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ProcessEventCompletionsServlet</servlet-name>
+        <url-pattern>/task/process_event_completions</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>PersistProductionResourcesServlet</servlet-name>
         <servlet-class>org.karmaexchange.bootstrap.PersistProductionResourcesServlet</servlet-class>
     </servlet>


### PR DESCRIPTION
Added event completion processing.
1. Completion tasks performed:
   a. Assign karma points to organizers and registered users
   b. Eliminate waiting list users for completed events.
2. A cron job has been created to run every 10 minutes to check for completed events. App engine bills in 15 minute increments and gives 28 free instance hours. In production we can set max instances to 1 to avoid any costs and the cron job along with warm up tasks might keep the jersey / objectify bootstrap overhead low.
3. Edits to the participant list performed after all completion tasks have been processed will queue new completion tasks that will be processed next time the cron job runs.

Note that cron jobs don't run on the dev server. So if you're creating a non-bootstrap test event and it is completed you can invoke the following URL to process completion tasks:

http://localhost:8080/task/process_event_completions

As usual, all events have to be recreated / edited to handle this update.

Other changes:
1. start time and end time can not be modified for completed events.
