### PR TITLE
Add reviews to bootstrap events and harden infrastructure.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/BaseDao.java
+++ b/src/main/java/org/karmaexchange/dao/BaseDao.java
@@ -192,20 +192,20 @@ public abstract class BaseDao<T extends BaseDao<T>> {
 
   protected void processLoad() {
     updateKey();
-    updatePermissionWithAdminCheck();
+    updatePermission();
   }
 
   protected void updateKey() {
     setKey(KeyWrapper.create(this).getKey());
   }
 
-  private final void updatePermissionWithAdminCheck() {
+  protected final void updatePermission() {
     if (isCurrentUserAdmin()) {
       permission = Permission.ALL;
     } else {
-      updatePermission();
+      permission = evalPermission();
     }
   }
 
-  protected abstract void updatePermission();
+  protected abstract Permission evalPermission();
 }

--- a/src/main/java/org/karmaexchange/dao/CauseType.java
+++ b/src/main/java/org/karmaexchange/dao/CauseType.java
@@ -39,7 +39,7 @@ public class CauseType extends NameBaseDao<CauseType> {
   }
 
   @Override
-  protected void updatePermission() {
-    setPermission(Permission.READ);
+  protected Permission evalPermission() {
+    return Permission.READ;
   }
 }

--- a/src/main/java/org/karmaexchange/dao/Image.java
+++ b/src/main/java/org/karmaexchange/dao/Image.java
@@ -126,14 +126,14 @@ public class Image extends IdBaseDao<Image> {
   }
 
   @Override
-  protected void updatePermission() {
+  protected Permission evalPermission() {
     // TODO(avaliani): fill this in. Organizers of events should have
     // the ability to delete pictures also if the picture is owned by an
     // event.
     if (KeyWrapper.toKey(getModificationInfo().getCreationUser()).equals(getCurrentUserKey())) {
-      permission = Permission.ALL;
+      return Permission.ALL;
     } else {
-      permission = Permission.READ;
+      return Permission.READ;
     }
   }
 }

--- a/src/main/java/org/karmaexchange/dao/Review.java
+++ b/src/main/java/org/karmaexchange/dao/Review.java
@@ -36,9 +36,9 @@ public class Review extends NameBaseDao<Review> {
   // At this point reviews will have no comments associated with them. Instead comments will
   // be associate with events and organization comments on facebook.
 
-  public void initPreUpsert(Key<?> owner) {
+  public void initPreUpsert(Key<?> owner, Key<User> authorKey) {
     if (name == null) {
-      name = getCurrentUserKey().getString();
+      name = authorKey.getString();
       this.owner = owner;
     }
   }
@@ -98,14 +98,14 @@ public class Review extends NameBaseDao<Review> {
   }
 
   @Override
-  protected void updatePermission() {
+  protected Permission evalPermission() {
     // TODO(avaliani): fill this in. Organizers of events should have
     // the ability to delete pictures also if the picture is owned by an
     // event.
     if (getAuthor().equals(getCurrentUserKey())) {
-      permission = Permission.ALL;
+      return Permission.ALL;
     } else {
-      permission = Permission.READ;
+      return Permission.READ;
     }
   }
 
@@ -114,6 +114,10 @@ public class Review extends NameBaseDao<Review> {
   }
 
   public static Key<Review> getKeyForCurrentUser(Key<?> owner) {
-    return Key.<Review>create(owner, Review.class, getCurrentUserKey().getString());
+    return getKeyForUser(owner, getCurrentUserKey());
+  }
+
+  public static Key<Review> getKeyForUser(Key<?> owner, Key<User> authorKey) {
+    return Key.<Review>create(owner, Review.class, authorKey.getString());
   }
 }

--- a/src/main/java/org/karmaexchange/dao/User.java
+++ b/src/main/java/org/karmaexchange/dao/User.java
@@ -141,11 +141,11 @@ public final class User extends NameBaseDao<User> {
   }
 
   @Override
-  protected void updatePermission() {
+  protected Permission evalPermission() {
     if (Key.create(this).equals(getCurrentUserKey())) {
-      setPermission(Permission.ALL);
+      return Permission.ALL;
     } else {
-      setPermission(Permission.READ);
+      return Permission.READ;
     }
   }
 

--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -210,14 +210,14 @@ public class EventResource extends BaseDaoResource<Event> {
   public void upsertReview(
       @PathParam("event_key") String eventKeyStr,
       Review review) {
-    Event.mutateEventReview(Key.<Event>create(eventKeyStr), review);
+    Event.mutateEventReviewForCurrentUser(Key.<Event>create(eventKeyStr), review);
   }
 
   @Path("{event_key}/review")
   @DELETE
   public void deleteReview(
       @PathParam("event_key") String eventKeyStr) {
-    Event.mutateEventReview(Key.<Event>create(eventKeyStr), null);
+    Event.mutateEventReviewForCurrentUser(Key.<Event>create(eventKeyStr), null);
   }
 
   @Path("{event_key}/review_comment_view")

--- a/src/main/java/org/karmaexchange/util/AdminUtil.java
+++ b/src/main/java/org/karmaexchange/util/AdminUtil.java
@@ -1,5 +1,7 @@
 package org.karmaexchange.util;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.Set;
 
 import org.karmaexchange.dao.User;
@@ -34,5 +36,20 @@ public class AdminUtil {
 
   public static void setCurrentUser(AdminTaskType type) {
     UserService.setCurrentUser(null, type.getKey());
+  }
+
+  public static void executeSubtaskAsUser(Key<User> userKey, AdminSubtask subtask) {
+    Key<User> prevAdminKey = UserService.getCurrentUserKey();
+    checkState(isAdminKey(prevAdminKey));
+    UserService.setCurrentUser(null, userKey);
+    try {
+      subtask.execute();
+    } finally {
+      UserService.setCurrentUser(null, prevAdminKey);
+    }
+  }
+
+  public interface AdminSubtask {
+    void execute();
   }
 }


### PR DESCRIPTION
- add reviews to boostrap test events
- organizer rating / event rating tampering fixes:
  - organizers and wait listed users can not be added after an event is completed
  - organizers can not be removed after an event is completed
  - users that have written a review for an event can not be deleted from an event
- miscellaneous code cleanup
