### PR TITLE
Add support for de-lombok'd javadocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ To start the app, use the [App Engine Maven Plugin](http://code.google.com/p/app
 
     mvn appengine:devserver
 
+To generate javadocs, run
+
+    mvn lombok:delombok
+    mvn javadoc:javadoc
+
 For further information, consult the [Java App Engine](https://developers.google.com/appengine/docs/java/overview) documentation.
 
 To see all the available goals for the App Engine plugin, run

--- a/pom.xml
+++ b/pom.xml
@@ -184,9 +184,60 @@
                   <disableUpdateCheck>true</disableUpdateCheck>
                 </configuration>
                -->
+            </plugin>
 
+            <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>0.11.8.0</version>
+                <configuration>
+                    <addOutputDirectory>false</addOutputDirectory>
+                    <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <sourcepath>${basedir}/target/generated-sources/delombok</sourcepath>
+                </configuration>
             </plugin>
         </plugins>
     </build>
 
+
+    <profiles>
+        <profile>
+            <id>lombok-needs-tools-jar</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok-maven-plugin</artifactId>
+                        <configuration>
+                            <addOutputDirectory>false</addOutputDirectory>
+                            <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
+                        </configuration>
+                        <version>0.11.8.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>sun.jdk</groupId>
+                                <artifactId>tools</artifactId>
+                                <version>1.7</version>
+                                <scope>system</scope>
+                                <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/org/karmaexchange/dao/Event.java
+++ b/src/main/java/org/karmaexchange/dao/Event.java
@@ -68,7 +68,7 @@ public final class Event extends IdBaseDao<Event> {
   @Index
   private Date endTime;
   @Ignore
-  protected Status status;
+  private Status status;
 
   private Image primaryImage;
   private List<Image> allImages = Lists.newArrayList();


### PR DESCRIPTION
Adds de-lombok'd javadoc support. In this way all methods exposed by classes are visible.

I had to remove the delombok goal from the build execution since that dramatically slowed down our most common build target "mvn appengine:devserver".

http://awhitford.github.io/lombok.maven/lombok-maven-plugin/usage.html
http://awhitford.github.io/lombok.maven/lombok-maven-plugin/faq.html#alt-src-setup

``` xml
                <executions>
                    <execution>
                        <phase>generate-sources</phase>
                        <goals>
                            <goal>delombok</goal>
                        </goals>
                    </execution>
                </executions>
```

The workaround is to explicitly invoke de-lombok prior to generating javadocs.

```
mvn lombok:delombok
mvn javadoc:javadoc
```

Or just create an alias 'kex-javadoc'

```
alias kex-javadoc='mvn lombok:delombok;mvn javadoc:javadoc'
```

There may be other ways to automatically invoke one maven goal prior to another... something to look into another time.
http://stackoverflow.com/questions/1427740/how-do-i-execute-a-set-of-goals-before-my-maven-plugin-runs
