### PR TITLE
Added support for suitable for event types and tag based keyword searches

### DIFF
--- a/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
+++ b/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
@@ -7,6 +7,7 @@ import java.io.PrintWriter;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -27,6 +28,7 @@ import org.karmaexchange.dao.Location;
 import org.karmaexchange.dao.OAuthCredential;
 import org.karmaexchange.dao.Rating;
 import org.karmaexchange.dao.Review;
+import org.karmaexchange.dao.SuitableForType;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
 import org.karmaexchange.util.AdminUtil;
@@ -131,26 +133,34 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
       USER6.getKey(), USER7.getKey(), USER8.getKey(), USER9.getKey(), USER10.getKey(),
       USER11.getKey(), USER12.getKey(), USER13.getKey());
     List<Key<User>> waitListedUsers = asList();
-    events.add(createEvent("Amir & Harish Organizer - SF Street Cleanup",
-      DateUtils.addDays(now, 1), 1, organizers, registeredUsers, waitListedUsers, 0, 100, 100));
+    Event event = createEvent("Amir & Harish Organizer - SF Street Cleanup",
+      DateUtils.addDays(now, 1), 1, organizers, registeredUsers, waitListedUsers, 0, 100, 100);
+    event.setSuitableForTypes(Lists.newArrayList(EnumSet.allOf(SuitableForType.class)));
+    events.add(event);
 
     organizers = asList(USER2.getKey());
     registeredUsers = asList(USER1.getKey(), USER4.getKey());
     waitListedUsers = asList(USER3.getKey(), USER5.getKey());
-    events.add(createEvent("Full event - Learning center",
-      DateUtils.addDays(now, 3), 3, organizers, registeredUsers, waitListedUsers, 0, 2, 100));
+    event = createEvent("Full event - Learning center",
+      DateUtils.addDays(now, 3), 3, organizers, registeredUsers, waitListedUsers, 0, 2, 100);
+    event.setSuitableForTypes(Lists.newArrayList(SuitableForType.AGE_55_PLUS));
+    events.add(event);
 
     organizers = asList(AMIR.getKey());
     registeredUsers = asList();
     waitListedUsers = asList();
-    events.add(createEvent("Amir Organizer - Date conflict - No one signed up",
-      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 0, 5, 100));
+    event = createEvent("Amir Organizer - Date conflict - No one signed up",
+      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 0, 5, 100);
+    event.setSuitableForTypes(Lists.newArrayList(SuitableForType.GROUPS));
+    events.add(event);
 
     organizers = asList(HARISH.getKey());
     registeredUsers = asList();
     waitListedUsers = asList();
-    events.add(createEvent("Harish Organizer - Date conflict - No one signed up",
-      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 0, 5, 100));
+    event = createEvent("Harish Organizer - Date conflict - No one signed up",
+      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 0, 5, 100);
+    event.setSuitableForTypes(Lists.newArrayList(SuitableForType.GROUPS));
+    events.add(event);
 
     // Past events.
     List<PendingReview> pendingReviews = Lists.newArrayList();
@@ -160,10 +170,11 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
       USER6.getKey(), USER7.getKey(), USER8.getKey(), USER9.getKey(), USER10.getKey(),
       USER11.getKey(), USER12.getKey(), USER13.getKey(), AMIR.getKey());
     waitListedUsers = asList(USER3.getKey());
-    Event event = createEvent("Harish as Organizer, Amir participant - SF Street Cleanup",
+    event = createEvent("Harish as Organizer, Amir participant - SF Street Cleanup",
       DateUtils.addDays(now, -6), 1,
       organizers, registeredUsers, waitListedUsers, 0, registeredUsers.size(), 100);
     events.add(event);
+    event.setSuitableForTypes(Lists.newArrayList(EnumSet.allOf(SuitableForType.class)));
     pendingReviews.add(PendingReview.create(event, USER4.getKey(),
       "I had a great time cleaning up the streets of SF.\n\n" +
       "Thanks to Harish for organizing such a wonderful event!", 5));
@@ -178,6 +189,7 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     event = createEvent("Amir as Organizer, Harish participant - SF Street Cleanup",
       DateUtils.addDays(now, -13), 1,
       organizers, registeredUsers, waitListedUsers, 0, registeredUsers.size(), 100);
+    event.setSuitableForTypes(Lists.newArrayList(EnumSet.allOf(SuitableForType.class)));
     events.add(event);
     pendingReviews.add(PendingReview.create(event, USER7.getKey(), null, 4));
 

--- a/src/main/java/org/karmaexchange/dao/CauseType.java
+++ b/src/main/java/org/karmaexchange/dao/CauseType.java
@@ -3,6 +3,8 @@ package org.karmaexchange.dao;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.karmaexchange.util.TagUtil;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -31,6 +33,14 @@ public class CauseType extends NameBaseDao<CauseType> {
 
   public static Key<CauseType> getKey(String name) {
     return Key.create(CauseType.class, name);
+  }
+
+  public static String getTag(Key<CauseType> causeKey) {
+    return TagUtil.createTag(getCauseTypeAsString(causeKey));
+  }
+
+  public static String getCauseTypeAsString(Key<CauseType> causeKey) {
+    return causeKey.getName();
   }
 
   private CauseType(String name, @Nullable PageRef pageRef) {

--- a/src/main/java/org/karmaexchange/dao/SuitableForType.java
+++ b/src/main/java/org/karmaexchange/dao/SuitableForType.java
@@ -1,0 +1,14 @@
+package org.karmaexchange.dao;
+
+import org.karmaexchange.util.TagUtil;
+
+public enum SuitableForType {
+  KIDS,
+  TEENS,
+  AGE_55_PLUS,
+  GROUPS;
+
+  public String getTag() {
+    return TagUtil.createTag("suitablefor" + name());
+  }
+}

--- a/src/main/java/org/karmaexchange/util/BoundedHashSet.java
+++ b/src/main/java/org/karmaexchange/util/BoundedHashSet.java
@@ -1,0 +1,35 @@
+package org.karmaexchange.util;
+
+import java.util.HashSet;
+
+@SuppressWarnings("serial")
+public class BoundedHashSet<E> extends HashSet<E> {
+
+  private int limit;
+
+  public static <E> BoundedHashSet<E> create(int limit) {
+    return new BoundedHashSet<E>(limit);
+  }
+
+  private BoundedHashSet(int limit) {
+    this.limit = limit;
+  }
+
+  @Override
+  public boolean add(E e) {
+    if (limitReached()) {
+      throw new IllegalStateException("Bounded hash set is full: limit=" + limit);
+    }
+    return super.add(e);
+  }
+
+  public void addIfSpace(E e) {
+    if (!limitReached()) {
+      add(e);
+    }
+  }
+
+  public boolean limitReached() {
+    return size() >= limit;
+  }
+}

--- a/src/main/java/org/karmaexchange/util/TagUtil.java
+++ b/src/main/java/org/karmaexchange/util/TagUtil.java
@@ -1,0 +1,19 @@
+package org.karmaexchange.util;
+
+import java.util.regex.Pattern;
+
+public class TagUtil {
+
+  public static final String TAG_PREFIX = "#";
+
+  public static final Pattern TAG_PREFIX_PATTERN = Pattern.compile("\\A#[a-zA-Z]");
+
+  public static String createTag(String text) {
+    String tagName = text.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+    // We're preventing strings like #1 from being parsed as tags.
+    if (tagName.isEmpty() || Character.isDigit(tagName.charAt(0))) {
+      throw new IllegalArgumentException("Unable to create tag for string: '" + text + "'");
+    }
+    return TAG_PREFIX + tagName;
+  }
+}

--- a/src/test/java/org/karmaexchange/dao/EventTest.java
+++ b/src/test/java/org/karmaexchange/dao/EventTest.java
@@ -2,9 +2,15 @@ package org.karmaexchange.dao;
 
 import static java.util.Arrays.asList;
 import static org.karmaexchange.util.JsonValidationTestUtil.validateJsonConversion;
+import static org.karmaexchange.util.TestUtil.debug;
+
+import java.util.EnumSet;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.karmaexchange.util.DatastoreTestUtil;
+
+import com.google.common.collect.Lists;
 
 public class EventTest extends PersistenceTestHelper {
 
@@ -27,6 +33,7 @@ public class EventTest extends PersistenceTestHelper {
     event.setRegistrationInfo(Event.RegistrationInfo.CAN_REGISTER);
     event.setMaxRegistrations(20);
     event.setKarmaPoints(100);
+    event.setSuitableForTypes(Lists.newArrayList(EnumSet.allOf(SuitableForType.class)));
   }
 
   @Test
@@ -37,5 +44,8 @@ public class EventTest extends PersistenceTestHelper {
   @Test
   public void testPersistence() throws Exception {
     validatePersistence(event);
+    if (debug) {
+      DatastoreTestUtil.dumpEntity(event);
+    }
   }
 }

--- a/src/test/java/org/karmaexchange/util/SearchUtilTest.java
+++ b/src/test/java/org/karmaexchange/util/SearchUtilTest.java
@@ -11,11 +11,13 @@ public class SearchUtilTest {
 
   @Test
   public void testGetSearchTokens() {
+    assertEquals(ImmutableSet.of("#tag"), getSearchableTokens("#tag", 10));
     assertEquals(
-      ImmutableSet.of("amir", "test", "case", "isn't", "amazing", "instructive", "bus"),
+      ImmutableSet.of("amir", "test", "case", "isn't", "amazing", "instructive", "bus",
+        "#tagsarealwaysextractedfirst"),
       getSearchableTokens(
         "Amir's test case isn't \"amazing\" but it. Is 'instructive' bus buses able " +
-        "token limit reached.", 7));
+        "token limit reached. #tagsAreAlwaysExtractedFirst but #1 and #123baby are not tags", 8));
   }
 
 }

--- a/src/test/java/org/karmaexchange/util/TagUtilTest.java
+++ b/src/test/java/org/karmaexchange/util/TagUtilTest.java
@@ -1,0 +1,25 @@
+package org.karmaexchange.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TagUtilTest {
+
+  @Test
+  public void testCreateTag() {
+    assertEquals("#thisisawesome408", TagUtil.createTag("This is-awesome' \"408\"!!!"));
+    verifyTagIsInvalid("1");
+    verifyTagIsInvalid("");
+  }
+
+  private void verifyTagIsInvalid(String tag) {
+    try {
+      TagUtil.createTag(tag);
+      fail("Exception not generated");
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(), "Unable to create tag for string: '" + tag + "'");
+    }
+  }
+
+}


### PR DESCRIPTION
Added support for suitable for event types and tag based keyword searches.

New field in the event object:

```
"suitableFor" : [ "KIDS", "TEENS", "AGE_55_PLUS", "GROUPS" ],
```

In the searchable tokens tags are automatically created for these tokens. They can be searched by using the # prefix with the following tags:

```
#suitableforage55plus
#suitableforteens
#suitableforkids
#suitableforgroups
```

Example:

```
http://localhost:8080/api/event?keywords=%23suitableforage55plus
```

Causes are now added as both keywords "Save the world" and as a single tag like #savetheworld.

Also, arbitrary tags in the description are now treated as tags. The hastag prefix is not removed.
