### PR TITLE
Add associatedOrganizations to event and event search apis.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/Organization.java
+++ b/src/main/java/org/karmaexchange/dao/Organization.java
@@ -351,25 +351,27 @@ public class Organization extends NameBaseDao<Organization> {
         rule.getMaxGrantableRole().hasEqualOrMoreCapabilities(reqRole);
   }
 
-  public static List<Key<Organization>> getOrgAndAncestorOrgs(Key<Organization> orgKey) {
+  public static List<Key<Organization>> getOrgAndAncestorOrgKeys(Key<Organization> orgKey) {
     List<Key<Organization>> allOrgs = Lists.newArrayList();
-    allOrgs.add(orgKey);
-    allOrgs.addAll(getAncestorOrgs(orgKey));
+    for (Organization org : getOrgAndAncestorOrgs(orgKey)) {
+      allOrgs.add(Key.create(org));
+    }
     return allOrgs;
   }
 
-  public static List<Key<Organization>> getAncestorOrgs(Key<Organization> orgKey) {
-    List<Key<Organization>> ancestorOrgKeys = Lists.newArrayList();
+  public static List<Organization> getOrgAndAncestorOrgs(Key<Organization> orgKey) {
+    List<Organization> allOrgs = Lists.newArrayList();
     while (orgKey != null) {
       Organization org = BaseDao.load(orgKey, ofy().transactionless());
-      if ((org != null) && (org.parentOrg != null)) {
-        orgKey = KeyWrapper.toKey(org.parentOrg);
-        ancestorOrgKeys.add(orgKey);
-      } else {
-        break;
+      orgKey = null;  // For next iteration.
+      if (org != null) {
+        allOrgs.add(org);
+        if (org.parentOrg != null) {
+          orgKey = KeyWrapper.toKey(org.parentOrg);
+        }
       }
     }
-    return ancestorOrgKeys;
+    return allOrgs;
   }
 
   @Override

--- a/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
@@ -13,7 +13,10 @@ import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.Event.RegistrationInfo;
 import org.karmaexchange.dao.Event.Status;
+import org.karmaexchange.dao.KeyWrapper;
 import org.karmaexchange.dao.Location;
+import org.karmaexchange.dao.Organization;
+import org.karmaexchange.dao.OrganizationNamedKeyWrapper;
 import org.karmaexchange.dao.ParticipantImage;
 import org.karmaexchange.dao.Permission;
 import org.karmaexchange.dao.AggregateRating;
@@ -35,6 +38,9 @@ public class EventSearchView {
 
   private String key;
   private Permission permission;
+
+  private KeyWrapper<Organization> organization;
+  private List<OrganizationNamedKeyWrapper> associatedOrganizations = Lists.newArrayList();
 
   private String title;
   private Location location;
@@ -86,6 +92,10 @@ public class EventSearchView {
   protected EventSearchView(Event event, @Nullable Review currentUserReview) {
     key = event.getKey();
     permission = event.getPermission();
+
+    organization = event.getOrganization();
+    associatedOrganizations = event.getAssociatedOrganizations();
+
     title = event.getTitle();
     location = event.getLocation();
     startTime = event.getStartTime();


### PR DESCRIPTION
Associated organizations includes the primary organization which is stored in the "organization" field along with all its ancestors. Duplication was required to simplify indexing of the "organization" field.

``` json
{
      "organization":{
        "key":"aglrYXJtYWRlbW9yHwsSDE9yZ2FuaXphdGlvbiINY29sdW1iaWEucGFyaww"
      },
      "associatedOrganizations":[
        {
          "key":"aglrYXJtYWRlbW9yHwsSDE9yZ2FuaXphdGlvbiINY29sdW1iaWEucGFyaww",
          "name":"Columbia Park Clubhouse"
        },
        {
          "key":"aglrYXJtYWRlbW9yFwsSDE9yZ2FuaXphdGlvbiIFYmdjc2YM",
          "name":"Boys & Girls Clubs of San Francisco"
        }
      ]
}
```
