### PR TITLE
Event album support for demo.

### DIFF
--- a/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
+++ b/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 
 import org.apache.commons.lang3.time.DateUtils;
 import org.karmaexchange.dao.Address;
+import org.karmaexchange.dao.AlbumRef;
 import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.CauseType;
 import org.karmaexchange.dao.Event;
@@ -29,6 +30,7 @@ import org.karmaexchange.dao.Organization.AutoMembershipRule;
 import org.karmaexchange.dao.OrganizationNamedKeyWrapper;
 import org.karmaexchange.dao.User.RegisteredEmail;
 import org.karmaexchange.dao.GeoPtWrapper;
+import org.karmaexchange.dao.ImageProviderType;
 import org.karmaexchange.dao.KeyWrapper;
 import org.karmaexchange.dao.Location;
 import org.karmaexchange.dao.OAuthCredential;
@@ -268,7 +270,8 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
       USER11.getKey(), USER12.getKey(), USER13.getKey());
     List<Key<User>> waitListedUsers = asList();
     Event event = createEvent("Amir & Harish Organizer - Soccer Camp", BGCSF_COLUMBIA_PARK,
-      DateUtils.addDays(now, 1), 1, organizers, registeredUsers, waitListedUsers, 100);
+      DateUtils.addDays(now, 1), 1, organizers, registeredUsers, waitListedUsers, 100,
+      "502904489789649");
     event.setSuitableForTypes(Lists.newArrayList(EnumSet.allOf(SuitableForType.class)));
     events.add(event);
 
@@ -276,7 +279,8 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     registeredUsers = asList(USER1.getKey(), USER4.getKey());
     waitListedUsers = asList(USER3.getKey(), USER5.getKey());
     event = createEvent("Full event - Learning center", BGCSF_TENDERLOIN,
-      DateUtils.addDays(now, 3), 3, organizers, registeredUsers, waitListedUsers, 2);
+      DateUtils.addDays(now, 3), 3, organizers, registeredUsers, waitListedUsers, 2,
+      "502905379789560");
     event.setSuitableForTypes(Lists.newArrayList(SuitableForType.AGE_55_PLUS));
     events.add(event);
 
@@ -284,7 +288,7 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     registeredUsers = asList();
     waitListedUsers = asList();
     event = createEvent("Amir Organizer - Date conflict - No one signed up", UNITED_WAY,
-      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 5);
+      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 5, null);
     event.setSuitableForTypes(Lists.newArrayList(SuitableForType.GROUPS));
     events.add(event);
 
@@ -292,7 +296,8 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     registeredUsers = asList();
     waitListedUsers = asList();
     event = createEvent("Harish Organizer - Date conflict - No one signed up", BENEVOLENT,
-      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 5);
+      DateUtils.addDays(now, 12), 1, organizers, registeredUsers, waitListedUsers, 5,
+      "502906079789490");
     event.setSuitableForTypes(Lists.newArrayList(SuitableForType.GROUPS));
     events.add(event);
 
@@ -306,7 +311,7 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     waitListedUsers = asList(USER3.getKey());
     event = createEvent("Harish as Organizer, Amir participant - Soccer Camp", BGCSF_TENDERLOIN,
       DateUtils.addDays(now, -6), 1,
-      organizers, registeredUsers, waitListedUsers, registeredUsers.size());
+      organizers, registeredUsers, waitListedUsers, registeredUsers.size(), "502904833122948");
     events.add(event);
     event.setSuitableForTypes(Lists.newArrayList(EnumSet.allOf(SuitableForType.class)));
     pendingReviews.add(PendingReview.create(event, USER4.getKey(),
@@ -322,7 +327,7 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     waitListedUsers = asList(USER3.getKey());
     event = createEvent("Amir as Organizer, Harish participant - Soccer Camp", BGCSF_COLUMBIA_PARK,
       DateUtils.addDays(now, -13), 1,
-      organizers, registeredUsers, waitListedUsers, registeredUsers.size());
+      organizers, registeredUsers, waitListedUsers, registeredUsers.size(), "502904726456292");
     event.setSuitableForTypes(Lists.newArrayList(EnumSet.allOf(SuitableForType.class)));
     events.add(event);
     pendingReviews.add(PendingReview.create(event, USER7.getKey(), null, 4));
@@ -331,14 +336,16 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     registeredUsers = asList(USER2.getKey(), USER5.getKey());
     waitListedUsers = asList();
     event = createEvent("Harish as Organizer - SF Street Cleanup", BENEVOLENT,
-      DateUtils.addDays(now, -20), 1, organizers, registeredUsers, waitListedUsers, 100);
+      DateUtils.addDays(now, -20), 1, organizers, registeredUsers, waitListedUsers, 100,
+      "502906933122738");
     events.add(event);
 
     organizers = asList(USER1.getKey(), AMIR.getKey());
     registeredUsers = asList(USER2.getKey(), USER5.getKey());
     waitListedUsers = asList();
     event = createEvent("Amir as Organizer - SF Street Cleanup", UNITED_WAY,
-      DateUtils.addDays(now, -27), 1, organizers, registeredUsers, waitListedUsers, 100);
+      DateUtils.addDays(now, -27), 1, organizers, registeredUsers, waitListedUsers, 100,
+      "502906759789422");
     events.add(event);
 
     return new CreateEventsResult(events, pendingReviews);
@@ -346,7 +353,7 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
 
   private static Event createEvent(String title, TestOrganization testOrg, Date startTime,
       int numHours, List<Key<User>> organizers, List<Key<User>> registeredUsers,
-      List<Key<User>> waitListedUsers, int maxRegistrations) {
+      List<Key<User>> waitListedUsers, int maxRegistrations, @Nullable String albumId) {
     eventNum++;
     Event event = new Event();
     event.setTitle(title);
@@ -367,6 +374,9 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
     event.setEndTime(DateUtils.addHours(startTime, numHours));
     event.setParticipants(createParticpantsList(organizers, registeredUsers, waitListedUsers));
     event.setMaxRegistrations(maxRegistrations);
+    if (albumId != null) {
+      event.setAlbum(new AlbumRef(albumId, ImageProviderType.FACEBOOK));
+    }
     return event;
   }
 

--- a/src/main/java/org/karmaexchange/dao/AlbumRef.java
+++ b/src/main/java/org/karmaexchange/dao/AlbumRef.java
@@ -1,0 +1,16 @@
+package org.karmaexchange.dao;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import com.googlecode.objectify.annotation.Embed;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Embed
+public class AlbumRef {
+  private String id;
+  private ImageProviderType urlProvider;
+}

--- a/src/main/java/org/karmaexchange/dao/Event.java
+++ b/src/main/java/org/karmaexchange/dao/Event.java
@@ -88,11 +88,13 @@ public final class Event extends IdBaseDao<Event> {
   @Ignore
   private Status status;
 
-  private Image primaryImage;
+  private AlbumRef album;
+
+  // private Image primaryImage;
   // BUG: This embedded list is not safe since Image has embedded objects that can be
   //      optionally null. See objectify serialization bug (issue #127).
   // TODO(avaliani): fix this embedded list.
-  private List<Image> allImages = Lists.newArrayList();
+  // private List<Image> allImages = Lists.newArrayList();
 
   @Index
   private List<KeyWrapper<Skill>> skillsPreferred = Lists.newArrayList();

--- a/src/main/java/org/karmaexchange/dao/Image.java
+++ b/src/main/java/org/karmaexchange/dao/Image.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import com.google.appengine.api.blobstore.BlobKey;
-import com.google.appengine.api.images.ImagesService;
 import com.google.appengine.api.images.ImagesServiceFactory;
 import com.google.appengine.api.images.ServingUrlOptions;
 import com.googlecode.objectify.Key;
@@ -38,27 +37,6 @@ public class Image extends IdBaseDao<Image> {
 
   private String caption;
   private GeoPtWrapper gpsLocation;  // Most images are tagged with gps information automatically.
-
-  public enum ImageProviderType {
-    FACEBOOK,
-
-    /**
-     * To get a 32 pixel sized version (aspect-ratio preserved) simply append
-     * "=s32" to the url:
-     * {@code "http://lh3.ggpht.com/SomeCharactersGoesHere=s32"}
-     * <p>
-     * To get a 32 pixel cropped version simply append "=s32-c":
-     * {@code "http://lh3.ggpht.com/SomeCharactersGoesHere=s32-c"}
-     *
-     * @see ImagesService#getServingUrl(ServingUrlOptions)
-     */
-    BLOBSTORE;
-
-    public static ImageProviderType toImageProviderType(
-        SocialNetworkProviderType socialNetworkProviderType) {
-      return ImageProviderType.valueOf(socialNetworkProviderType.name());
-    }
-  }
 
   public static Image createAndPersist(Key<?> owner, BlobKey blobKey, String caption) {
     ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey).secureUrl(true);

--- a/src/main/java/org/karmaexchange/dao/ImageProviderType.java
+++ b/src/main/java/org/karmaexchange/dao/ImageProviderType.java
@@ -1,0 +1,27 @@
+package org.karmaexchange.dao;
+
+import org.karmaexchange.provider.SocialNetworkProvider.SocialNetworkProviderType;
+
+import com.google.appengine.api.images.ImagesService;
+import com.google.appengine.api.images.ServingUrlOptions;
+
+public enum ImageProviderType {
+  FACEBOOK,
+
+  /**
+   * To get a 32 pixel sized version (aspect-ratio preserved) simply append
+   * "=s32" to the url:
+   * {@code "http://lh3.ggpht.com/SomeCharactersGoesHere=s32"}
+   * <p>
+   * To get a 32 pixel cropped version simply append "=s32-c":
+   * {@code "http://lh3.ggpht.com/SomeCharactersGoesHere=s32-c"}
+   *
+   * @see ImagesService#getServingUrl(ServingUrlOptions)
+   */
+  BLOBSTORE;
+
+  public static ImageProviderType toImageProviderType(
+      SocialNetworkProviderType socialNetworkProviderType) {
+    return ImageProviderType.valueOf(socialNetworkProviderType.name());
+  }
+}

--- a/src/main/java/org/karmaexchange/dao/ImageRef.java
+++ b/src/main/java/org/karmaexchange/dao/ImageRef.java
@@ -2,7 +2,6 @@ package org.karmaexchange.dao;
 
 import javax.annotation.Nullable;
 
-import org.karmaexchange.dao.Image.ImageProviderType;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/org/karmaexchange/dao/ParticipantImage.java
+++ b/src/main/java/org/karmaexchange/dao/ParticipantImage.java
@@ -4,7 +4,6 @@ import javax.annotation.Nullable;
 
 import lombok.Data;
 
-import org.karmaexchange.dao.Image.ImageProviderType;
 
 import com.google.common.base.Predicate;
 import com.googlecode.objectify.annotation.Embed;

--- a/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.karmaexchange.dao.AlbumRef;
 import org.karmaexchange.dao.BaseDao;
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.Event.RegistrationInfo;
@@ -47,7 +48,7 @@ public class EventSearchView {
   private Date startTime;
   private Date endTime;
   private Status status;
-  private ImageUrlView primaryImage;
+  private AlbumRef album;
   private RegistrationInfo registrationInfo;
 
   private List<ParticipantImage> cachedParticipantImages = Lists.newArrayList();
@@ -101,9 +102,7 @@ public class EventSearchView {
     startTime = event.getStartTime();
     endTime = event.getEndTime();
     status = event.getStatus();
-    if (event.getPrimaryImage() != null) {
-      // PrimaryImage(ImageUrlView.create(event.getPrimaryImage()));
-    }
+    album = event.getAlbum();
     karmaPoints = event.getKarmaPoints();
     cachedParticipantImages = event.getCachedParticipantImages();
     numAttending = event.getNumAttending();

--- a/src/main/java/org/karmaexchange/resources/msg/ImageUrlView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ImageUrlView.java
@@ -2,7 +2,7 @@ package org.karmaexchange.resources.msg;
 
 import lombok.Data;
 
-import org.karmaexchange.dao.Image.ImageProviderType;
+import org.karmaexchange.dao.ImageProviderType;
 import org.karmaexchange.dao.ImageRef;
 
 @Data

--- a/src/test/java/org/karmaexchange/dao/UserTest.java
+++ b/src/test/java/org/karmaexchange/dao/UserTest.java
@@ -13,7 +13,6 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.karmaexchange.dao.Image.ImageProviderType;
 import org.karmaexchange.dao.User.RegisteredEmail;
 import org.karmaexchange.util.DatastoreTestUtil;
 


### PR DESCRIPTION
Both the event and event search apis now have an album field. Bootstrap fills in the album field for some of the events (to simulate that not all events will have albums).

album: {
id: "502904489789649"
urlProvider: "FACEBOOK"
}
