### PR TITLE
More label colors

### DIFF
--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -102,12 +102,41 @@ text-align:center;
   padding: 5px 20px;
 }
 
-span.kex-labelstyle-84b6eb {
+/* 
+ * The kex-labelstyle-tag* colors are all colors that can be shown together to highlight 
+ * different tags. Currently these colors consist of blue, green, yellow, and grey.
+ */
+.kex-labelstyle-bright-blue, .kex-labelstyle-tag-1 {
   background-color: #84b6eb !important;
   color: #1c2733 !important;
 }
 
-span.kex-label {
+.kex-labelstyle-bright-aquamarine, .kex-labelstyle-tag-2 {
+  background-color: #006b75 !important;
+  color: #fff !important;
+}
+
+.kex-labelstyle-light-yellow, .kex-labelstyle-tag-3 {
+  background-color: #fef2c0 !important;
+  color: #333026 !important;
+}
+
+.kex-labelstyle-light-green, .kex-labelstyle-tag-4 {
+  background-color: #bfe5bf !important;
+  color: #2a332a !important;
+}
+
+.kex-labelstyle-light-blue, .kex-labelstyle-tag-5 {
+  background-color: #bfdadc !important;
+  color: #2c3233 !important;
+}
+
+.kex-labelstyle-light-gray, .kex-labelstyle-tag-6 {
+  background-color: #cccccc !important;
+  color: #333333 !important;
+}
+
+.kex-label {
   display: inline-block;
   padding: 2px 4px;
   border-radius: 2px;

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -111,27 +111,22 @@ text-align:center;
   color: #1c2733 !important;
 }
 
-.kex-labelstyle-bright-aquamarine, .kex-labelstyle-tag-2 {
-  background-color: #006b75 !important;
-  color: #fff !important;
-}
-
-.kex-labelstyle-light-yellow, .kex-labelstyle-tag-3 {
+.kex-labelstyle-light-yellow, .kex-labelstyle-tag-2 {
   background-color: #fef2c0 !important;
   color: #333026 !important;
 }
 
-.kex-labelstyle-light-green, .kex-labelstyle-tag-4 {
+.kex-labelstyle-light-green, .kex-labelstyle-tag-3 {
   background-color: #bfe5bf !important;
   color: #2a332a !important;
 }
 
-.kex-labelstyle-light-blue, .kex-labelstyle-tag-5 {
+.kex-labelstyle-light-blue, .kex-labelstyle-tag-4 {
   background-color: #bfdadc !important;
   color: #2c3233 !important;
 }
 
-.kex-labelstyle-light-gray, .kex-labelstyle-tag-6 {
+.kex-labelstyle-light-gray, .kex-labelstyle-tag-5 {
   background-color: #cccccc !important;
   color: #333333 !important;
 }

--- a/src/main/webapp/partials/me.html
+++ b/src/main/webapp/partials/me.html
@@ -47,7 +47,7 @@
 				    		<div class="row-fluid">
 		    					<strong >{{event.startTime | date:'mediumDate'}}</strong>
 		    					<a href="#/event/{{event.key}}"><strong>{{event.title}} </strong></a> 
-		    					<span class="kex-label kex-labelstyle-84b6eb pull-right" ng-show="{ORGANIZER:true}[event.registrationInfo]">organizer</span>
+		    					<span class="kex-label kex-labelstyle-light-blue pull-right" ng-show="{ORGANIZER:true}[event.registrationInfo]">organizer</span>
 		    				</div>
 		    				<div class="row-fluid">
 		    					<small class="muted">{{event.startTime | date:'shortTime'}} - {{event.endTime | date:'shortTime'}}</small>					
@@ -77,7 +77,7 @@
 			    		<div class="row-fluid">
 	    					<strong >{{event.startTime | date:'mediumDate'}}</strong>
 	    					<a href="#/event/{{event.key}}"><strong>{{event.title}} </strong></a> 
-	    					<span class="kex-label kex-labelstyle-84b6eb pull-right" ng-show="{ORGANIZER:true}[event.registrationInfo]">organizer</span>
+	    					<span class="kex-label kex-labelstyle-light-blue pull-right" ng-show="{ORGANIZER:true}[event.registrationInfo]">organizer</span>
 	    				</div>
 	    				<div class="row-fluid">
 	    					<small class="muted">{{event.startTime | date:'shortTime'}} - {{event.endTime | date:'shortTime'}}</small>					


### PR DESCRIPTION
Fixes #191 

See #191 for the colors that I picked.

``` css
/* 
 * The kex-labelstyle-tag* colors are all colors that can be shown together to highlight 
 * different tags. Currently these colors consist of blue, green, yellow, and grey.
 */
.kex-labelstyle-bright-blue, .kex-labelstyle-tag-1 {
  background-color: #84b6eb !important;
  color: #1c2733 !important;
}

.kex-labelstyle-light-yellow, .kex-labelstyle-tag-2 {
  background-color: #fef2c0 !important;
  color: #333026 !important;
}

.kex-labelstyle-light-green, .kex-labelstyle-tag-3 {
  background-color: #bfe5bf !important;
  color: #2a332a !important;
}

.kex-labelstyle-light-blue, .kex-labelstyle-tag-4 {
  background-color: #bfdadc !important;
  color: #2c3233 !important;
}

.kex-labelstyle-light-gray, .kex-labelstyle-tag-5 {
  background-color: #cccccc !important;
  color: #333333 !important;
}
```
