### PR TITLE
Add organizationDetails to the event and event search views.

### DIFF
--- a/src/main/java/org/karmaexchange/dao/Event.java
+++ b/src/main/java/org/karmaexchange/dao/Event.java
@@ -1165,7 +1165,7 @@ public final class Event extends IdBaseDao<Event> {
   @Data
   @Embed
   @NoArgsConstructor
-  private static class CompletionTaskTracker {
+  public static class CompletionTaskTracker {
 
     // NOTE: The embedded lists are safe since CompletionTaskWrapper has been modified to avoid
     //       encountering the objectify serialization bug (issue #127).

--- a/src/main/java/org/karmaexchange/resources/BaseDaoResourceEx.java
+++ b/src/main/java/org/karmaexchange/resources/BaseDaoResourceEx.java
@@ -1,0 +1,104 @@
+package org.karmaexchange.resources;
+
+import static java.lang.String.format;
+import static org.karmaexchange.util.OfyService.ofy;
+
+import java.net.URI;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.karmaexchange.dao.BaseDao;
+import org.karmaexchange.resources.msg.BaseDaoView;
+import org.karmaexchange.resources.msg.ErrorResponseMsg;
+import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
+
+import com.googlecode.objectify.Key;
+
+public abstract class BaseDaoResourceEx<T extends BaseDao<T>, U extends BaseDaoView<T>> {
+
+  public static final int DEFAULT_NUM_SEARCH_RESULTS = 25;
+
+  @Context
+  protected UriInfo uriInfo;
+  @Context
+  protected Request request;
+  @Context
+  protected ServletContext servletContext;
+
+
+  // TODO(avaliani): re-add support for list resources using GenericEntity.
+  /*
+  @GET
+  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  public List<T> getResources() {
+    return BaseDao.loadAll(getResourceClass());
+  }
+  */
+
+  @POST
+  @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  public Response upsertResource(U resourceView) {
+    T resource = resourceView.getDao();
+    preProcessUpsert(resource);
+    BaseDao.upsert(resource);
+    URI uri = uriInfo.getAbsolutePathBuilder().path(resource.getKey()).build();
+    return Response.created(uri).build();
+  }
+
+  @Path("{resource}")
+  @GET
+  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  public Response getResource(@PathParam("resource") String key) {
+    return Response.ok(createBaseDaoView(getResourceObj(key))).build();
+  }
+
+  protected T getResourceObj(String key) {
+    T resource = BaseDao.<T>load(key);
+    if (resource == null) {
+      throw ErrorResponseMsg.createException("resource does not exist", ErrorInfo.Type.BAD_REQUEST);
+    }
+    return resource;
+  }
+
+  protected abstract U createBaseDaoView(T resource);
+
+  @Path("{resource}")
+  @POST
+  @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  public Response updateResource(@PathParam("resource") String key, U resourceView) {
+    T resource = resourceView.getDao();
+    preProcessUpsert(resource);
+    if (resource.isKeyComplete() && !key.equals(Key.create(resource).getString())) {
+      throw ErrorResponseMsg.createException(
+        format("the resource key [%s] does not match the url path key [%s]",
+          Key.create(resource).getString(), key),
+        ErrorInfo.Type.BAD_REQUEST);
+    }
+    BaseDao.upsert(resource);
+    return Response.created(uriInfo.getAbsolutePath()).build();
+  }
+
+  @Path("{resource}")
+  @DELETE
+  public void deleteResource(@PathParam("resource") String key) {
+    ofy().delete().key(Key.<T>create(key)).now();
+  }
+
+  protected abstract Class<T> getResourceClass();
+
+  protected void preProcessUpsert(T resource) {
+    // No-op.
+  }
+}

--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -30,6 +30,7 @@ import org.karmaexchange.dao.Review;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.resources.msg.EventParticipantView;
 import org.karmaexchange.resources.msg.EventSearchView;
+import org.karmaexchange.resources.msg.EventView;
 import org.karmaexchange.resources.msg.ExpandedEventSearchView;
 import org.karmaexchange.resources.msg.ListResponseMsg;
 import org.karmaexchange.resources.msg.ListResponseMsg.PagingInfo;
@@ -44,7 +45,7 @@ import com.google.common.collect.ImmutableList;
 import com.googlecode.objectify.Key;
 
 @Path("/event")
-public class EventResource extends BaseDaoResource<Event> {
+public class EventResource extends BaseDaoResourceEx<Event, EventView> {
 
   public static final String START_TIME_PARAM = "start_time";
   public static final String SEARCH_TYPE_PARAM = "type";
@@ -64,6 +65,11 @@ public class EventResource extends BaseDaoResource<Event> {
   @Override
   protected Class<Event> getResourceClass() {
     return Event.class;
+  }
+
+  @Override
+  protected EventView createBaseDaoView(Event event) {
+    return new EventView(event);
   }
 
   @GET

--- a/src/main/java/org/karmaexchange/resources/msg/BaseDaoView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/BaseDaoView.java
@@ -1,0 +1,13 @@
+package org.karmaexchange.resources.msg;
+
+import javax.xml.bind.annotation.XmlTransient;
+
+public interface BaseDaoView<T> {
+
+  @XmlTransient
+  T getDao();
+
+  // Required to prevent this field from propagating to the json api.
+  @XmlTransient
+  boolean isKeyComplete();
+}

--- a/src/main/java/org/karmaexchange/resources/msg/EventView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventView.java
@@ -1,0 +1,59 @@
+package org.karmaexchange.resources.msg;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Delegate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.karmaexchange.dao.AggregateRating;
+import org.karmaexchange.dao.BaseDao;
+import org.karmaexchange.dao.Event;
+import org.karmaexchange.dao.KeyWrapper;
+import org.karmaexchange.dao.Organization;
+import org.karmaexchange.dao.PageRef;
+
+@XmlRootElement
+@Data
+@NoArgsConstructor
+public class EventView implements BaseDaoView<Event> {
+
+  @Delegate
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.NONE)
+  private Event event = new Event();
+
+  private OrgDetails organizationDetails;
+
+  public EventView(Event event) {
+    this.event = event;
+    Organization org = BaseDao.load(KeyWrapper.toKey(event.getOrganization()));
+    if (org != null) {
+      organizationDetails = new OrgDetails(org);
+    }
+  }
+
+  @Override
+  public Event getDao() {
+    return event;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class OrgDetails {
+    private String orgName;
+    private PageRef page;
+    private long karmaPoints;
+    private AggregateRating eventRating;
+
+    public OrgDetails(Organization org) {
+      orgName = org.getOrgName();
+      page = org.getPage();
+      karmaPoints = org.getKarmaPoints();
+      eventRating = org.getEventRating();
+    }
+  }
+}

--- a/src/main/java/org/karmaexchange/resources/msg/ExpandedEventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/ExpandedEventSearchView.java
@@ -41,11 +41,13 @@ public class ExpandedEventSearchView extends EventSearchView {
     if (event.getRegistrationInfo() == RegistrationInfo.REGISTERED) {
       review = BaseDao.load(Review.getKeyForCurrentUser(event));
     }
-    return new ExpandedEventSearchView(event, review);
+    Organization org = BaseDao.load(KeyWrapper.toKey(event.getOrganization()));
+    return new ExpandedEventSearchView(event, org, review);
   }
 
-  private ExpandedEventSearchView(Event event, @Nullable Review currentUserReview) {
-    super(event, currentUserReview);
+  private ExpandedEventSearchView(Event event, @Nullable Organization fetchedOrg,
+      @Nullable Review currentUserReview) {
+    super(event, fetchedOrg, currentUserReview);
     description = event.getDescription();
 
     User user = BaseDao.load(KeyWrapper.toKey(event.getOrganizers().get(0)));


### PR DESCRIPTION
In the event and event search view In addition to the organization field which contains the key for the organization, there is now an organizationDetails field which contains extra information useful for the UI.

``` json
{
   "organizationDetails":{
      "orgName":"Columbia Park Clubhouse",
      "page":{
         "url":"https://www.facebook.com/columbia.park",
         "urlProvider":"FACEBOOK"
      },
      "karmaPoints":60,
      "eventRating":{
         "value":4.0,
         "sum":4.0,
         "count":1
      }
   },
}
```
