### PR TITLE
Add leaderboard support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,17 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.appengine.tools</groupId>
+            <artifactId>appengine-pipeline</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine.tools</groupId>
+            <artifactId>appengine-mapreduce</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.sun.jersey.jersey-test-framework</groupId>
             <artifactId>jersey-test-framework-grizzly</artifactId>
             <version>1.17</version>

--- a/src/main/java/org/karmaexchange/bootstrap/PersistTestResourcesServlet.java
+++ b/src/main/java/org/karmaexchange/bootstrap/PersistTestResourcesServlet.java
@@ -7,6 +7,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.karmaexchange.util.ServletUtil;
+
 @SuppressWarnings("serial")
 public class PersistTestResourcesServlet extends HttpServlet {
 
@@ -15,7 +17,8 @@ public class PersistTestResourcesServlet extends HttpServlet {
     resp.setContentType("text/plain");
     PrintWriter statusWriter = resp.getWriter();
     new CauseTypesBootstrapTask(statusWriter, req.getCookies()).execute();
-    new TestResourcesBootstrapTask(statusWriter, req.getCookies()).execute();
+    new TestResourcesBootstrapTask(statusWriter, req.getCookies(), ServletUtil.getBaseUrl(req))
+        .execute();
   }
 
   @Override

--- a/src/main/java/org/karmaexchange/bootstrap/PurgeAllResourcesServlet.java
+++ b/src/main/java/org/karmaexchange/bootstrap/PurgeAllResourcesServlet.java
@@ -13,6 +13,7 @@ import org.karmaexchange.dao.CauseType;
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.EventComment;
 import org.karmaexchange.dao.Image;
+import org.karmaexchange.dao.Leaderboard;
 import org.karmaexchange.dao.Organization;
 import org.karmaexchange.dao.Review;
 import org.karmaexchange.dao.Skill;
@@ -51,6 +52,8 @@ public class PurgeAllResourcesServlet extends HttpServlet {
         ofy().load().type(EventComment.class).keys().iterable();
     Iterable<Key<Image>> imageKeys = ofy().load().type(Image.class).keys().iterable();
     Iterable<Key<Review>> reviewKeys = ofy().load().type(Review.class).keys().iterable();
+    Iterable<Key<Leaderboard>> leaderboardKeys =
+        ofy().load().type(Leaderboard.class).keys().iterable();
 
     ofy().delete().keys(eventKeys);
     ofy().delete().keys(userKeys);
@@ -60,6 +63,7 @@ public class PurgeAllResourcesServlet extends HttpServlet {
     ofy().delete().keys(eventCommentKeys);
     ofy().delete().keys(imageKeys);
     ofy().delete().keys(reviewKeys);
+    ofy().delete().keys(leaderboardKeys);
 
     statusWriter.println("Deleted all resources.");
   }

--- a/src/main/java/org/karmaexchange/dao/BaseDao.java
+++ b/src/main/java/org/karmaexchange/dao/BaseDao.java
@@ -6,6 +6,7 @@ import static org.karmaexchange.util.UserService.isCurrentUserAdmin;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
@@ -119,6 +120,12 @@ public abstract class BaseDao<T extends BaseDao<T>> {
     return results;
   }
 
+  public static <T extends BaseDao<T>> Map<Key<T>, T> loadAsMap(Collection<Key<T>> keys) {
+    Map<Key<T>, T> result = ofy().load().keys(keys);
+    processLoadResults(result.values());
+    return result;
+  }
+
   public static <T extends BaseDao<T>> List<T> loadAll(Class<T> resourceClass) {
     List<T> resources = ofy().load().type(resourceClass).list();
     processLoadResults(resources);
@@ -220,7 +227,7 @@ public abstract class BaseDao<T extends BaseDao<T>> {
   protected void processDelete() {
   }
 
-  protected void processLoad() {
+  public void processLoad() {
     updateKey();
     updatePermission();
   }

--- a/src/main/java/org/karmaexchange/dao/ImageUrlView.java
+++ b/src/main/java/org/karmaexchange/dao/ImageUrlView.java
@@ -1,10 +1,11 @@
-package org.karmaexchange.resources.msg;
+package org.karmaexchange.dao;
 
 import lombok.Data;
 
-import org.karmaexchange.dao.ImageProviderType;
-import org.karmaexchange.dao.ImageRef;
 
+import com.googlecode.objectify.annotation.Embed;
+
+@Embed
 @Data
 public class ImageUrlView {
   private String url;

--- a/src/main/java/org/karmaexchange/dao/Leaderboard.java
+++ b/src/main/java/org/karmaexchange/dao/Leaderboard.java
@@ -1,0 +1,110 @@
+package org.karmaexchange.dao;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.karmaexchange.task.LeaderboardReducer.LeaderboardScore;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import com.google.common.collect.Lists;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Cache;
+import com.googlecode.objectify.annotation.Embed;
+import com.googlecode.objectify.annotation.Entity;
+
+@XmlRootElement
+@Entity
+@Cache  // Caching is valuable for the leaderboard since it is fetched by key.
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper=true)
+@ToString(callSuper=true)
+public class Leaderboard extends NameBaseDao<Leaderboard> {
+
+  public enum LeaderboardType {
+    ALL_TIME,
+    THIRTY_DAY
+  }
+
+  private List<LeaderboardScoreAndUserInfo> scores = Lists.newArrayList();
+
+  public Leaderboard(Key<Organization> orgKey, LeaderboardType type,
+      List<LeaderboardScore> scores, Map<Key<User>, User> usersMap) {
+    // Using the same parent causes entity group contention. Which is not needed.
+    name = createName(orgKey, type);
+
+    for (LeaderboardScore score : scores) {
+      User user = usersMap.get(score.getUserKey());
+      if (user != null) {
+        this.scores.add(new LeaderboardScoreAndUserInfo(user, score.getLeaderboardKarmaPoints()));
+      }
+    }
+    Collections.sort(this.scores,
+      LeaderboardScoreAndUserInfo.KarmaPointsAndUserInfoComparator.INSTANCE);
+  }
+
+  private static String createName(Key<Organization> orgKey, LeaderboardType type) {
+    return Organization.getUniqueOrgId(orgKey) + type.toString();
+  }
+
+  public static Key<Leaderboard> createKey(Key<Organization> orgKey, LeaderboardType type) {
+    return Key.<Leaderboard>create(Leaderboard.class, createName(orgKey, type));
+  }
+
+  @Override
+  protected Permission evalPermission() {
+    // Admin tasks create the leaderboard. Everyone else only has read access.
+    return Permission.READ;
+  }
+
+  @Embed
+  @Data
+  @NoArgsConstructor
+  private static class LeaderboardScoreAndUserInfo {
+    private UserInfoKeyWrapper user;
+    private long leaderboardKarmaPoints;
+
+    public LeaderboardScoreAndUserInfo(User user, long leaderboardKarmaPoints) {
+      this.user = new UserInfoKeyWrapper(user);
+      this.leaderboardKarmaPoints = leaderboardKarmaPoints;
+    }
+
+    public static class KarmaPointsAndUserInfoComparator
+        implements Comparator<LeaderboardScoreAndUserInfo> {
+
+      public static final KarmaPointsAndUserInfoComparator INSTANCE =
+          new KarmaPointsAndUserInfoComparator();
+
+      @Override
+      public int compare(LeaderboardScoreAndUserInfo score1, LeaderboardScoreAndUserInfo score2) {
+        // Higher scored items come first.
+        int result = Long.compare(score2.leaderboardKarmaPoints, score1.leaderboardKarmaPoints);
+        if (result != 0) {
+          return result;
+        }
+        result = nullSafeIgnoreCaseStringComparator(score1.getUser().getFirstName(),
+          score2.getUser().getFirstName());
+        if (result != 0) {
+          return result;
+        }
+        return nullSafeIgnoreCaseStringComparator(score1.getUser().getLastName(),
+          score2.getUser().getLastName());
+      }
+
+      private int nullSafeIgnoreCaseStringComparator(String s1, String s2) {
+        if ((s1 == null) || (s2 == null)) {
+          return (s1 == null) ? -1 : 1;
+        }
+        return s1.compareToIgnoreCase(s2);
+      }
+    }
+  }
+}

--- a/src/main/java/org/karmaexchange/dao/Organization.java
+++ b/src/main/java/org/karmaexchange/dao/Organization.java
@@ -117,6 +117,10 @@ public class Organization extends NameBaseDao<Organization> {
     return pageName.toLowerCase();
   }
 
+  public static String getUniqueOrgId(Key<Organization> orgKey) {
+    return orgKey.getName();
+  }
+
   public static String getSearchTokenSuffix(Key<Organization> orgKey) {
     return orgKey.getName();
   }

--- a/src/main/java/org/karmaexchange/dao/User.java
+++ b/src/main/java/org/karmaexchange/dao/User.java
@@ -176,7 +176,7 @@ public final class User extends NameBaseDao<User> {
   }
 
   @Override
-  protected void processLoad() {
+  public void processLoad() {
     super.processLoad();
     updateEventAttendanceHistoryPct();
   }

--- a/src/main/java/org/karmaexchange/dao/UserInfoKeyWrapper.java
+++ b/src/main/java/org/karmaexchange/dao/UserInfoKeyWrapper.java
@@ -1,29 +1,35 @@
-package org.karmaexchange.resources.msg;
+package org.karmaexchange.dao;
 
-import org.karmaexchange.dao.ImageUrlView;
-import org.karmaexchange.dao.User;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Embed;
+
+@Embed
 @Data
 @NoArgsConstructor
-public class UserSummaryInfoView {
+@EqualsAndHashCode(callSuper=true)
+@ToString(callSuper=true)
+public class UserInfoKeyWrapper extends KeyWrapper<User> {
   private String firstName;
   private String lastName;
   private String nickName;
-  private String key;
   private ImageUrlView profileImage;
   private long karmaPoints;
 
-  public UserSummaryInfoView(User user) {
+  public UserInfoKeyWrapper(User user) {
+    super(Key.create(user));
     firstName = user.getFirstName();
     lastName = user.getLastName();
     nickName = user.getNickName();
-    key = user.getKey();
     if (user.getProfileImage() != null) {
       profileImage = ImageUrlView.create(user.getProfileImage());
     }
     karmaPoints = user.getKarmaPoints();
   }
+
 }

--- a/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/EventSearchView.java
@@ -106,9 +106,7 @@ public class EventSearchView {
         reviewKeys.add(Review.getKeyForCurrentUser(event));
       }
     }
-    Map<Key<Review>, Review> reviews = ofy().load().keys(reviewKeys);
-    BaseDao.processLoadResults(reviews.values());
-    return reviews;
+    return BaseDao.loadAsMap(reviewKeys);
   }
 
   protected EventSearchView(Event event, @Nullable Organization fetchedOrg,

--- a/src/main/java/org/karmaexchange/task/ComputeLeaderboardServlet.java
+++ b/src/main/java/org/karmaexchange/task/ComputeLeaderboardServlet.java
@@ -1,0 +1,64 @@
+package org.karmaexchange.task;
+
+import static org.karmaexchange.util.OfyService.ofy;
+
+import java.io.IOException;
+
+import org.karmaexchange.dao.Event;
+import org.karmaexchange.dao.Organization;
+import org.karmaexchange.task.LeaderboardMapper.UserKarmaRecord;
+import org.karmaexchange.util.ServletUtil;
+
+import com.google.appengine.tools.mapreduce.MapReduceJob;
+import com.google.appengine.tools.mapreduce.MapReduceSettings;
+import com.google.appengine.tools.mapreduce.MapReduceSpecification;
+import com.google.appengine.tools.mapreduce.Marshallers;
+import com.google.appengine.tools.mapreduce.inputs.DatastoreInput;
+import com.google.appengine.tools.mapreduce.outputs.NoOutput;
+import com.googlecode.objectify.Key;
+
+@SuppressWarnings("serial")
+public class ComputeLeaderboardServlet extends TaskQueueAdminTaskServlet {
+
+  private static final int DEFAULT_MAP_SHARD_COUNT = 2;
+  private static final int DEFAULT_REDUCE_SHARD_COUNT = 2;
+  private static final String PIPELINE_STATUS_PATH = "/_ah/pipeline/status.html";
+  private static final String PIPELINE_STATUS_ID_PARAM = "root";
+
+  @Override
+  protected void execute() throws IOException {
+    redirectToMapReduceStatusUrl(
+      startComputeLeaderboardMapReduce());
+  }
+
+  public static String startComputeLeaderboardMapReduce() {
+    String eventKind = ofy().getFactory().getMetadata(Event.class).getKeyMetadata().getKind();
+    return MapReduceJob.start(
+        MapReduceSpecification.of(
+            "ComputeLeaderboardMapReduce",
+            new DatastoreInput(eventKind, DEFAULT_MAP_SHARD_COUNT),
+            new LeaderboardMapper(),
+            Marshallers.<Key<Organization>>getSerializationMarshaller(),
+            Marshallers.<UserKarmaRecord>getSerializationMarshaller(),
+            new LeaderboardReducer(),
+            NoOutput.<Void, Void>create(DEFAULT_REDUCE_SHARD_COUNT)),
+        getSettings());
+  }
+
+  private static MapReduceSettings getSettings() {
+    MapReduceSettings settings = new MapReduceSettings()
+        .setWorkerQueueName("mapreduce-workers")
+        .setControllerQueueName("default");
+    return settings;
+  }
+
+  private void redirectToMapReduceStatusUrl(String mapReduceJobId) throws IOException {
+    String destinationUrl = getMapReduceStatusUrl(ServletUtil.getBaseUrl(req), mapReduceJobId);
+    resp.sendRedirect(destinationUrl);
+  }
+
+  public static String getMapReduceStatusUrl(String baseUrl, String mapReduceJobId) {
+    return baseUrl + PIPELINE_STATUS_PATH + "?" +
+        PIPELINE_STATUS_ID_PARAM + "=" + mapReduceJobId;
+  }
+}

--- a/src/main/java/org/karmaexchange/task/LeaderboardMapper.java
+++ b/src/main/java/org/karmaexchange/task/LeaderboardMapper.java
@@ -1,0 +1,66 @@
+package org.karmaexchange.task;
+
+import static org.karmaexchange.util.OfyService.ofy;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import org.karmaexchange.dao.Event;
+import org.karmaexchange.dao.Event.EventParticipant;
+import org.karmaexchange.dao.KeyWrapper;
+import org.karmaexchange.dao.Organization;
+import org.karmaexchange.dao.OrganizationNamedKeyWrapper;
+import org.karmaexchange.dao.User;
+import org.karmaexchange.dao.Event.Status;
+import org.karmaexchange.task.LeaderboardMapper.UserKarmaRecord;
+import org.karmaexchange.util.AdminUtil;
+import org.karmaexchange.util.AdminUtil.AdminTaskType;
+import org.karmaexchange.util.UserService;
+
+import lombok.Data;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.mapreduce.Mapper;
+import com.googlecode.objectify.Key;
+
+public class LeaderboardMapper extends Mapper<Entity, Key<Organization>, UserKarmaRecord> {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public void map(Entity dsEvent) {
+    AdminUtil.setCurrentUser(AdminTaskType.MAP_REDUCE);
+    try {
+      mapAsAdmin(dsEvent);
+    } finally {
+      UserService.clearCurrentUser();
+    }
+  }
+
+  private void mapAsAdmin(Entity dsEvent) {
+    Event event = ofy().toPojo(dsEvent);
+    event.processLoad();
+    if (event.getStatus() != Status.COMPLETED) {
+      return;
+    }
+    for (OrganizationNamedKeyWrapper associatedOrg : event.getAssociatedOrganizations()) {
+      for (EventParticipant participant : event.getParticipants()) {
+        if (participant.getType().countAsAttended()) {
+          getContext().emit(KeyWrapper.toKey(associatedOrg),
+            new UserKarmaRecord(KeyWrapper.toKey(participant.getUser()), event.getKarmaPoints(),
+              event.getEndTime()));
+        }
+      }
+    }
+  }
+
+  @Data
+  public static class UserKarmaRecord implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Key<User> userKey;
+    private final int eventKarmaPoints;
+    private final Date eventEndTime;
+  }
+}

--- a/src/main/java/org/karmaexchange/task/LeaderboardReducer.java
+++ b/src/main/java/org/karmaexchange/task/LeaderboardReducer.java
@@ -1,0 +1,134 @@
+package org.karmaexchange.task;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Data;
+
+import org.apache.commons.lang3.time.DateUtils;
+import org.karmaexchange.dao.BaseDao;
+import org.karmaexchange.dao.Leaderboard;
+import org.karmaexchange.dao.Organization;
+import org.karmaexchange.dao.User;
+import org.karmaexchange.dao.Leaderboard.LeaderboardType;
+import org.karmaexchange.task.LeaderboardMapper.UserKarmaRecord;
+import org.karmaexchange.util.AdminUtil;
+import org.karmaexchange.util.UserService;
+import org.karmaexchange.util.AdminUtil.AdminTaskType;
+
+import com.google.appengine.tools.mapreduce.Reducer;
+import com.google.appengine.tools.mapreduce.ReducerInput;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.googlecode.objectify.Key;
+
+public class LeaderboardReducer extends Reducer<Key<Organization>, UserKarmaRecord, Void> {
+
+  private static final long serialVersionUID = 1L;
+  private static final int MAX_LEADERBOARD_SIZE = 10;
+
+  @Override
+  public void reduce(Key<Organization> orgKey, ReducerInput<UserKarmaRecord> userKarmaRecords) {
+    AdminUtil.setCurrentUser(AdminTaskType.MAP_REDUCE);
+    try {
+      reduceAsAdmin(orgKey, userKarmaRecords);
+    } finally {
+      UserService.clearCurrentUser();
+    }
+  }
+
+  private void reduceAsAdmin(Key<Organization> orgKey,
+      ReducerInput<UserKarmaRecord> userKarmaRecords) {
+    Date now = new Date();
+    Date thirtyDayCutOff = DateUtils.addDays(now, -30);
+    Map<Key<User>, LeaderboardScore> allTimeLeaderboardMap = Maps.newHashMap();
+    Map<Key<User>, LeaderboardScore> thirtyDayLeaderboardMap = Maps.newHashMap();
+
+    while (userKarmaRecords.hasNext()) {
+      UserKarmaRecord record = userKarmaRecords.next();
+
+      addToLeaderboardMap(allTimeLeaderboardMap, record);
+
+      if (record.getEventEndTime().after(thirtyDayCutOff)) {
+        addToLeaderboardMap(thirtyDayLeaderboardMap, record);
+      }
+    }
+
+    List<LeaderboardScore> sortedAllTimeLeaderboardScores =
+        sortAndTrimLeaderboard(allTimeLeaderboardMap);
+    List<LeaderboardScore> sortedThirtyDayLeaderboardScores =
+        sortAndTrimLeaderboard(thirtyDayLeaderboardMap);
+
+    // Once BaseDao is fixed to handle loads properly these loads will be asynchronous.
+    Map<Key<User>, User> allTimeLeaderboardUsers =
+        fetchLeaderboardUsers(sortedAllTimeLeaderboardScores);
+    Map<Key<User>, User> thirtyDayLeaderboardUsers =
+        fetchLeaderboardUsers(sortedThirtyDayLeaderboardScores);
+
+    persistLeaderboard(orgKey, sortedAllTimeLeaderboardScores, allTimeLeaderboardUsers,
+      LeaderboardType.ALL_TIME);
+    persistLeaderboard(orgKey, sortedThirtyDayLeaderboardScores, thirtyDayLeaderboardUsers,
+      LeaderboardType.THIRTY_DAY);
+  }
+
+  private void addToLeaderboardMap(Map<Key<User>, LeaderboardScore> leaderboardMap,
+      UserKarmaRecord record) {
+    LeaderboardScore score = leaderboardMap.get(record.getUserKey());
+    if (score == null) {
+      leaderboardMap.put(record.getUserKey(), new LeaderboardScore(record));
+    } else {
+      score.add(record);
+    }
+  }
+
+  private List<LeaderboardScore> sortAndTrimLeaderboard(
+      Map<Key<User>, LeaderboardScore> leaderboadMap) {
+    List<LeaderboardScore> sortedScores = Lists.newArrayList(leaderboadMap.values());
+    Collections.sort(sortedScores, LeaderboardScore.KarmaPointsComparator.INSTANCE);
+    if (sortedScores.size() > MAX_LEADERBOARD_SIZE) {
+      sortedScores.subList(MAX_LEADERBOARD_SIZE, sortedScores.size()).clear();
+    }
+    return sortedScores;
+  }
+
+  private Map<Key<User>, User> fetchLeaderboardUsers(List<LeaderboardScore> scores) {
+    List<Key<User>> userKeys = Lists.newArrayList();
+    for (LeaderboardScore score : scores) {
+      userKeys.add(score.getUserKey());
+    }
+    return BaseDao.loadAsMap(userKeys);
+  }
+
+  private void persistLeaderboard(Key<Organization> orgKey, List<LeaderboardScore> sortedScores,
+      Map<Key<User>, User> usersMap, LeaderboardType type) {
+    BaseDao.upsert(new Leaderboard(orgKey, type, sortedScores, usersMap));
+  }
+
+  @Data
+  public static class LeaderboardScore {
+    private final Key<User> userKey;
+    private long leaderboardKarmaPoints;
+
+    public LeaderboardScore(UserKarmaRecord record) {
+      userKey = record.getUserKey();
+      leaderboardKarmaPoints = record.getEventKarmaPoints();
+    }
+
+    public void add(UserKarmaRecord record) {
+      leaderboardKarmaPoints += record.getEventKarmaPoints();
+    }
+
+    public static class KarmaPointsComparator implements Comparator<LeaderboardScore> {
+      public static final KarmaPointsComparator INSTANCE = new KarmaPointsComparator();
+
+      @Override
+      public int compare(LeaderboardScore score1, LeaderboardScore score2) {
+        // Higher scored items come first.
+        return Long.compare(score2.leaderboardKarmaPoints, score1.leaderboardKarmaPoints);
+      }
+    }
+  }
+}

--- a/src/main/java/org/karmaexchange/util/AdminUtil.java
+++ b/src/main/java/org/karmaexchange/util/AdminUtil.java
@@ -20,6 +20,7 @@ public class AdminUtil {
     BOOTSTRAP,
     OAUTH_FILTER,
     TASK_QUEUE,
+    MAP_REDUCE,
     REGISTRATION;
 
     public Key<User> getKey() {

--- a/src/main/java/org/karmaexchange/util/OfyService.java
+++ b/src/main/java/org/karmaexchange/util/OfyService.java
@@ -5,6 +5,7 @@ import org.karmaexchange.dao.CauseType;
 import org.karmaexchange.dao.Event;
 import org.karmaexchange.dao.EventComment;
 import org.karmaexchange.dao.Image;
+import org.karmaexchange.dao.Leaderboard;
 import org.karmaexchange.dao.Organization;
 import org.karmaexchange.dao.Review;
 import org.karmaexchange.dao.Skill;
@@ -28,6 +29,8 @@ public class OfyService {
     ObjectifyService.register(EventComment.class);
     ObjectifyService.register(Image.class);
     ObjectifyService.register(Review.class);
+    ObjectifyService.register(Leaderboard.class);
+    // Make sure to update PurgeAllResourcesServlet if a new class is added.
   }
 
   public static Objectify ofy() {

--- a/src/main/java/org/karmaexchange/util/ServletUtil.java
+++ b/src/main/java/org/karmaexchange/util/ServletUtil.java
@@ -4,9 +4,12 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -52,4 +55,15 @@ public class ServletUtil {
     }
   }
 
+  public static String getBaseUrl(HttpServletRequest req) {
+    URL requestUrl;
+    try {
+      requestUrl = new URL(req.getRequestURL().toString());
+    } catch (MalformedURLException e) {
+      // Impossible.
+      throw new RuntimeException(e);
+    }
+    String portString = requestUrl.getPort() == -1 ? "" : ":" + requestUrl.getPort();
+    return requestUrl.getProtocol() + "://" + requestUrl.getHost() + portString;
+  }
 }

--- a/src/main/webapp/WEB-INF/cron.xml
+++ b/src/main/webapp/WEB-INF/cron.xml
@@ -5,4 +5,10 @@
         <description>Process completed events</description>
         <schedule>every 10 minutes</schedule>
     </cron>
+
+    <cron>
+        <url>/task/compute_leaderboard</url>
+        <description>Compute organization leaderboards</description>
+        <schedule>every 24 hours</schedule>
+    </cron>
 </cronentries>

--- a/src/main/webapp/WEB-INF/queue.xml
+++ b/src/main/webapp/WEB-INF/queue.xml
@@ -1,0 +1,21 @@
+<queue-entries>
+    <total-storage-limit>1000M</total-storage-limit>
+    <queue>
+        <name>default</name>
+        <rate>100/s</rate>
+        <bucket-size>100</bucket-size>
+        <retry-parameters>
+            <task-age-limit>3d</task-age-limit>
+        </retry-parameters>
+        <max-concurrent-requests>300</max-concurrent-requests>
+    </queue>
+    <queue>
+        <name>mapreduce-workers</name>
+        <rate>100/s</rate>
+        <bucket-size>100</bucket-size>
+        <retry-parameters>
+            <task-age-limit>3d</task-age-limit>
+        </retry-parameters>
+        <max-concurrent-requests>100</max-concurrent-requests>
+    </queue>
+</queue-entries>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -96,6 +96,15 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>ComputeLeaderboardServlet</servlet-name>
+        <servlet-class>org.karmaexchange.task.ComputeLeaderboardServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ComputeLeaderboardServlet</servlet-name>
+        <url-pattern>/task/compute_leaderboard</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>PersistProductionResourcesServlet</servlet-name>
         <servlet-class>org.karmaexchange.bootstrap.PersistProductionResourcesServlet</servlet-class>
     </servlet>
@@ -149,11 +158,30 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <url-pattern>/bootstrap/provider/fb/register</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>mapreduce</servlet-name>
+        <servlet-class>com.google.appengine.tools.mapreduce.MapReduceServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>mapreduce</servlet-name>
+        <url-pattern>/mapreduce/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>pipeline</servlet-name>
+        <servlet-class>com.google.appengine.tools.pipeline.impl.servlets.PipelineServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>pipeline</servlet-name>
+        <url-pattern>/_ah/pipeline/*</url-pattern>
+    </servlet-mapping>
+
     <security-constraint>
         <web-resource-collection>
-            <url-pattern>/task/*</url-pattern>
             <url-pattern>/bootstrap/*</url-pattern>
             <url-pattern>/local_test/*</url-pattern>
+            <url-pattern>/mapreduce/*</url-pattern>
+            <url-pattern>/task/*</url-pattern>
         </web-resource-collection>
         <auth-constraint>
             <role-name>admin</role-name>

--- a/src/main/webapp/bootstrap/index.html
+++ b/src/main/webapp/bootstrap/index.html
@@ -97,6 +97,12 @@ div {
   </div>
 
   <div>
+    <form action="/task/compute_leaderboard">
+      <button type="submit" class="btn">Compute organization leaderboards</button>
+    </form>
+  </div>
+
+  <div>
     <form action="/bootstrap/purge_resources">
       <button type="submit" class="btn btn-danger">Delete all resources</button>
     </form>


### PR DESCRIPTION
- Two leaderboards created per org. ALL_TIME and THIRTY_DAY
- Cron job to update leaderboard every 24 hours. Modification info in leaderboard indicates when the leaderboard was refreshed. The UI should display it.
- API to fetch the leaderboard
  
  /api/{org_key}/leaderboard?type={leaderboard_type}
  
  leaderboard_type=ALL_TIME | THIRTY_DAY
- Convenience: "Compute organization leaderboard" button to launch map-reduce in /bootstrap
  Note that this is automatically done when "Bootstrap test resources" is clicked.
