### PR TITLE
Resolve app engine map-reduce guava dependency conflict.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <appengine.app.version>1</appengine.app.version>
-        <appengine.target.version>1.8.3</appengine.target.version>
+        <appengine.target.version>1.8.5</appengine.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -114,10 +114,26 @@
             <artifactId>appengine-pipeline</artifactId>
             <version>RELEASE</version>
         </dependency>
+        <!-- Included to resolve guava version dependency conflict. See mapreduce exclusions
+             section comment. -->
+        <dependency>
+            <groupId>com.google.appengine.tools</groupId>
+            <artifactId>appengine-gcs-client</artifactId>
+            <version>RELEASE</version>
+        </dependency>
         <dependency>
             <groupId>com.google.appengine.tools</groupId>
             <artifactId>appengine-mapreduce</artifactId>
             <version>RELEASE</version>
+            <!-- Mapreduce depends on guava min version 14.0 and max version 14.99.
+                 But it also depends on appengine-gcs-client which depends on guava version 15.
+                 To resolve this dependency conflict we ignore the mapreduce guava dependency. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.javadocmd</groupId>


### PR DESCRIPTION
Resolves the following app engine dependency conflict.

[ERROR] Failed to execute goal on project karmaexchange: Could not resolve dependencies for project org.karmaexchange:karmaexchange:war:1.0-SNAPSHOT: Failed to collect dependencies for org.karmaexchange:karmaexchange:war:1.0-SNAPSHOT: Could not resolve version conflict among [com.google.appengine.tools:appengine-mapreduce:jar:RELEASE -> com.google.appengine.tools:appengine-gcs-client:jar:[0.3,0.4) -> com.google.guava:guava:jar:[15.0,15.99], com.google.appengine.tools:appengine-mapreduce:jar:RELEASE -> com.google.guava:guava:jar:[14.0,14.99]] -> [Help 1]
