### PR TITLE
Use a promise to access $rootScope.me

### DIFF
--- a/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
+++ b/src/main/java/org/karmaexchange/bootstrap/TestResourcesBootstrapTask.java
@@ -219,11 +219,13 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
                 "If your property is stolen while volunteering that is your responsibility."),
              createWaiver("After school tutoring waiver",
                 "You are responsible for any property you bring."))),
+
     BGCSF_COLUMBIA_PARK("columbia.park",
       "https://bgcsf.thankyou4caring.org/page.aspx?pid=298",
       AMIR,
       asList(
-        TestOrgMembership.of(USER1, null, Organization.Role.ORGANIZER),
+        TestOrgMembership.of(USER1, Organization.Role.ORGANIZER, null),
+        TestOrgMembership.of(USER8, null, Organization.Role.ORGANIZER),
         TestOrgMembership.of(HARISH, Organization.Role.ORGANIZER, null),
         TestOrgMembership.of(POONUM, Organization.Role.ORGANIZER, null)),
       BGCSF,
@@ -231,14 +233,15 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
       asList(createWaiver("Soccer clinic waiver",
         "If you are injured while volunteering Columbia Park BGCSF is not liable.\n\n" +
         "If your property is stolen while volunteering that is your responsibility."))),
+
     BGCSF_TENDERLOIN("Tenderloin.clubhouse",
       "https://bgcsf.thankyou4caring.org/page.aspx?pid=298",
       HARISH,
       asList(
         TestOrgMembership.of(POONUM, Organization.Role.ADMIN, null),
-        TestOrgMembership.of(USER1, null, Organization.Role.ORGANIZER),
+        TestOrgMembership.of(USER1, Organization.Role.ORGANIZER, null),
         TestOrgMembership.of(USER2, Organization.Role.ORGANIZER, null),
-        TestOrgMembership.of(AMIR, Organization.Role.ORGANIZER, null)),
+        TestOrgMembership.of(USER8, null, Organization.Role.ORGANIZER)),
       BGCSF),
 
     BENEVOLENT("benevolent.net",
@@ -249,7 +252,7 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
         TestOrgMembership.of(USER7, Organization.Role.MEMBER, Organization.Role.ORGANIZER),
         TestOrgMembership.of(USER6, Organization.Role.MEMBER, Organization.Role.ADMIN),
         TestOrgMembership.of(USER5, Organization.Role.ORGANIZER, Organization.Role.ADMIN),
-        TestOrgMembership.of(USER1, Organization.Role.MEMBER, null),
+        TestOrgMembership.of(USER1, Organization.Role.ORGANIZER, null),
         TestOrgMembership.of(USER2, null, Organization.Role.MEMBER),
         TestOrgMembership.of(USER3, null, Organization.Role.ADMIN))),
 
@@ -260,7 +263,7 @@ public class TestResourcesBootstrapTask extends BootstrapTask {
         TestOrgMembership.of(USER7, Organization.Role.MEMBER, Organization.Role.ORGANIZER),
         TestOrgMembership.of(USER6, Organization.Role.MEMBER, Organization.Role.ADMIN),
         TestOrgMembership.of(USER5, Organization.Role.ORGANIZER, Organization.Role.ADMIN),
-        TestOrgMembership.of(USER1, Organization.Role.MEMBER, null),
+        TestOrgMembership.of(USER1, Organization.Role.ORGANIZER, null),
         TestOrgMembership.of(USER2, null, Organization.Role.MEMBER),
         TestOrgMembership.of(USER3, null, Organization.Role.ADMIN)));
 

--- a/src/main/java/org/karmaexchange/resources/MeResource.java
+++ b/src/main/java/org/karmaexchange/resources/MeResource.java
@@ -84,7 +84,7 @@ public class MeResource {
   @GET
   @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
   public ListResponseMsg<OrganizationMembershipView> getOrgs() {
-    return UserResource.getOrgs(getCurrentUserKey());
+    return UserResource.getOrgs(getCurrentUserKey(), uriInfo);
   }
 
   @Path("profile_image")

--- a/src/main/java/org/karmaexchange/resources/OrganizationResource.java
+++ b/src/main/java/org/karmaexchange/resources/OrganizationResource.java
@@ -48,6 +48,7 @@ public class OrganizationResource extends BaseDaoResource<Organization> {
 
   public static final String NAME_PREFIX_PARAM = "name_prefix";
   public static final String ROLE_PARAM = "role";
+  public static final String MIN_ROLE_PARAM = "min_role";
   public static final String MEMBERSHIP_STATUS_PARAM = "membership_status";
   public static final String LEADERBOARD_TYPE_PARAM = "type";
   public static final String INCLUDE_PARENT_ORGS_PARAM = "include_parent_orgs";

--- a/src/main/java/org/karmaexchange/resources/msg/OrganizationMembershipView.java
+++ b/src/main/java/org/karmaexchange/resources/msg/OrganizationMembershipView.java
@@ -13,6 +13,7 @@ import org.karmaexchange.dao.AggregateRating;
 import org.karmaexchange.dao.CauseType;
 import org.karmaexchange.dao.KeyWrapper;
 import org.karmaexchange.dao.Organization;
+import org.karmaexchange.dao.Organization.Role;
 import org.karmaexchange.dao.PageRef;
 import org.karmaexchange.dao.User;
 import org.karmaexchange.dao.User.OrganizationMembership;
@@ -42,12 +43,15 @@ public class OrganizationMembershipView {
   @Nullable
   private Organization.Role requestedRole;
 
-  public static List<OrganizationMembershipView> create(User user) {
+  public static List<OrganizationMembershipView> create(User user, Role minRole) {
     // The number of memberships a user should have is small. Therefore, fetch them all and
     // then sort them.
     Map<Key<Organization>, OrganizationMembership> membershipMap = Maps.newHashMap();
     for (OrganizationMembership membership : user.getOrganizationMemberships()) {
-      membershipMap.put(KeyWrapper.toKey(membership.getOrganization()), membership);
+      if ((membership.getRole() != null) &&
+          membership.getRole().hasEqualOrMoreCapabilities(minRole)) {
+        membershipMap.put(KeyWrapper.toKey(membership.getOrganization()), membership);
+      }
     }
     List<Organization> organizations = Lists.newArrayList();
     for (Organization org : ofy().load().keys(membershipMap.keySet()).values()) {

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -171,7 +171,7 @@
                         <li>
                             <a href="#!/org"><i class="icon-group icon-white"></i> Organizations</a>
                         </li>
-                        <li ng-show="me && orgs && (orgs.data.length > 0)">
+                        <li ng-show="isOrganizer">
                             <a href="#!/event/add"><i class="icon-plus icon-white"></i> Create Events</a>
                         </li>
                     </ul>


### PR DESCRIPTION
- use a promise to access $rootScope.me. Avoids redundant fetches of me. And cleans up me update handling..
- optimization - we can check if the user is an organizer of an organization by looking at the me object. No query is required.
- bug: ui was incorrectly displaying users as organizers even though they were not
  organizers. The organizers json api was not being used correctly.
  Json api for orgs a user belongs to has also been updated.
- bug: bootstrap test memberships were semi-bogus. Made them more accurate.
