### PR TITLE
Handle event search view login register timing bug.

### DIFF
--- a/src/main/webapp/partials/events.html
+++ b/src/main/webapp/partials/events.html
@@ -132,8 +132,8 @@
                                                                 <td>
                                                                         <p>
 
-                                                                                <button ng-show="{CAN_REGISTER:true}[modelEvent.registrationInfo]" class="btn btn-success" login-click="register('REGISTERED')"><i class="icon-ok icon-white"></i> Register</button>
-                                                                                <button ng-show="{CAN_WAIT_LIST:true}[modelEvent.registrationInfo]" class="btn btn-success" login-click="register('WAIT_LISTED')"><i class="icon-ok icon-white"></i> Wait list</button>
+                                                                                <button ng-show="{CAN_REGISTER:true}[modelEvent.registrationInfo]" class="btn btn-success" ng-click="register('REGISTERED')"><i class="icon-ok icon-white"></i> Register</button>
+                                                                                <button ng-show="{CAN_WAIT_LIST:true}[modelEvent.registrationInfo]" class="btn btn-success" ng-click="register('WAIT_LISTED')"><i class="icon-ok icon-white"></i> Wait list</button>
                                                                                 <!--
                                                                                         Not really needed anymore since we have a label containing the registration info.
 


### PR DESCRIPTION
When a user logs in by clicking the register button the variables me, goalInfo, and the events array all get updated because the user has changed. The register action depends on these. Therefore it needs to wait until they are resolved.

RecyclablePromiseFactory was newly introduced to simplify handling of promises that recycle on event changes like login.
