### PR TITLE
perf: fix warmup by doing request forwarding - exercises the full stack!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,26 +114,10 @@
             <artifactId>appengine-pipeline</artifactId>
             <version>RELEASE</version>
         </dependency>
-        <!-- Included to resolve guava version dependency conflict. See mapreduce exclusions
-             section comment. -->
-        <dependency>
-            <groupId>com.google.appengine.tools</groupId>
-            <artifactId>appengine-gcs-client</artifactId>
-            <version>RELEASE</version>
-        </dependency>
         <dependency>
             <groupId>com.google.appengine.tools</groupId>
             <artifactId>appengine-mapreduce</artifactId>
             <version>RELEASE</version>
-            <!-- Mapreduce depends on guava min version 14.0 and max version 14.99.
-                 But it also depends on appengine-gcs-client which depends on guava version 15.
-                 To resolve this dependency conflict we ignore the mapreduce guava dependency. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.javadocmd</groupId>

--- a/src/main/java/org/karmaexchange/bootstrap/WarmupServlet.java
+++ b/src/main/java/org/karmaexchange/bootstrap/WarmupServlet.java
@@ -1,29 +1,26 @@
 package org.karmaexchange.bootstrap;
 
-import java.io.PrintWriter;
+import java.io.IOException;
 
-import org.karmaexchange.resources.EventResource;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("serial")
-public class WarmupServlet extends BootstrapTaskServlet {
+public class WarmupServlet extends HttpServlet {
 
   @Override
-  public BootstrapTask createTask() {
-    return new WarmupTask(statusWriter);
-  }
-
-}
-
-class WarmupTask extends BootstrapTask {
-
-  public WarmupTask(PrintWriter statusWriter) {
-    super(statusWriter);
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    getServletContext()
+      .getRequestDispatcher("/api/event")
+      .forward(req, resp);
   }
 
   @Override
-  protected void performTask() {
-    statusWriter.println("Warming up event search...");
-    EventResource.eventSearchWarmup();
-    statusWriter.println("Warmup completed.");
+  public void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    doGet(req, resp);
   }
 }

--- a/src/main/java/org/karmaexchange/resources/EventResource.java
+++ b/src/main/java/org/karmaexchange/resources/EventResource.java
@@ -86,7 +86,7 @@ public class EventResource extends BaseDaoResourceEx<Event, EventView> {
   }
 
   @GET
-  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
   public ListResponseMsg<EventSearchView> getResources() {
     return eventSearch(uriInfo, ImmutableList.<FilterQueryClause>of(), null);
   }
@@ -244,7 +244,7 @@ public class EventResource extends BaseDaoResourceEx<Event, EventView> {
 
   @Path("{event_key}/expanded_search_view")
   @GET
-  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
   public Response getExpandedEventSearchView(
     @PathParam("event_key") String eventKeyStr) {
     Event event = getResourceObj(eventKeyStr);
@@ -253,7 +253,7 @@ public class EventResource extends BaseDaoResourceEx<Event, EventView> {
 
   @Path("{event_key}/participants/{participant_type}")
   @GET
-  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
   public ListResponseMsg<EventParticipantView> getParticipants(
       @PathParam("event_key") String eventKeyStr,
       @PathParam("participant_type") ParticipantType participantType) {
@@ -268,7 +268,7 @@ public class EventResource extends BaseDaoResourceEx<Event, EventView> {
 
   @Path("{event_key}/participants/{participant_type}")
   @POST
-  @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  @Consumes({MediaType.APPLICATION_JSON})
   public Response upsertParticipants(
       @PathParam("event_key") String eventKeyStr,
       @PathParam("participant_type") ParticipantType participantType,
@@ -290,7 +290,7 @@ public class EventResource extends BaseDaoResourceEx<Event, EventView> {
 
   @Path("{event_key}/review")
   @GET
-  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
   public Review getReview(
       @PathParam("event_key") String eventKeyStr) {
     return ofy().load().key(Review.getKeyForCurrentUser(Key.<Event>create(eventKeyStr))).now();
@@ -298,7 +298,7 @@ public class EventResource extends BaseDaoResourceEx<Event, EventView> {
 
   @Path("{event_key}/review")
   @POST
-  @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  @Consumes({MediaType.APPLICATION_JSON})
   public void upsertReview(
       @PathParam("event_key") String eventKeyStr,
       Review review) {
@@ -314,7 +314,7 @@ public class EventResource extends BaseDaoResourceEx<Event, EventView> {
 
   @Path("{event_key}/review_comment_view")
   @GET
-  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
   public ListResponseMsg<ReviewCommentView> getReviewComments(
       @PathParam("event_key") String eventKeyStr) {
     Key<Event> eventKey = OfyUtil.createKey(eventKeyStr);


### PR DESCRIPTION
Other fixes:
- this also fixes a build issues with the mapreduce library which now depends on guava 15 by removing the exclusions workaround added in pull #237 

```
[INFO] java.lang.NoSuchMethodError: com.google.common.base.Stopwatch.createUnstarted()Lcom/google/common/base/Stopwatch;
[INFO]  at com.google.appengine.tools.cloudstorage.RetryHelper.runWithRetries(RetryHelper.java:123)
[INFO]  at com.google.appengine.tools.mapreduce.MapReduceJob.checkQueueSettings(MapReduceJob.java:110)
[INFO]  at com.google.appengine.tools.mapreduce.MapReduceJob.start(MapReduceJob.java:100)
[INFO]  at org.karmaexchange.task.ComputeLeaderboardServlet.startComputeLeaderboardMapReduce(ComputeLeaderboardServlet.java:35)
```
