### PR TITLE
Use the org id instead of org key when processing sync requests.

### DIFF
--- a/src/main/java/org/karmaexchange/resources/derived/SourceEvent.java
+++ b/src/main/java/org/karmaexchange/resources/derived/SourceEvent.java
@@ -95,6 +95,7 @@ public class SourceEvent {
     event.setOwner(
       SourceEventNamespaceDao.createKey(sourceInfo.getOrgKey(), sourceKey).getString());
     event.setId(EVENT_ID);
+    event.setOrganization(KeyWrapper.create(sourceInfo.getOrgKey()));
     event.setSourceEventInfo(new SourceEventInfo(sourceKey));
     mapSourceParticipants();
     // TODO(avaliani): map source participants
@@ -146,9 +147,9 @@ public class SourceEvent {
         "key is a derived field and can not be specified",
         ErrorInfo.Type.BAD_REQUEST);
     }
-    if (!KeyWrapper.toKey(event.getOrganization()).equals(orgKey)) {
+    if (event.getOrganization() != null) {
       throw ErrorResponseMsg.createException(
-        "organization field does not match specified organization",
+        "organization field should not be specified",
         ErrorInfo.Type.BAD_REQUEST);
     }
 

--- a/src/main/java/org/karmaexchange/resources/derived/SourceEventResource.java
+++ b/src/main/java/org/karmaexchange/resources/derived/SourceEventResource.java
@@ -28,7 +28,6 @@ import org.karmaexchange.resources.msg.ErrorResponseMsg.ErrorInfo;
 import org.karmaexchange.util.AdminUtil;
 import org.karmaexchange.util.AdminUtil.AdminSubtask;
 import org.karmaexchange.util.AdminUtil.AdminTaskType;
-import org.karmaexchange.util.OfyUtil;
 
 import com.googlecode.objectify.Key;
 
@@ -45,11 +44,10 @@ public class SourceEventResource {
   @POST
   @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
   public void syncEvents(
-      @QueryParam("org_key") String orgKeyStr,
+      @QueryParam("org_id") String orgId,
       @QueryParam("org_secret") String orgSecret,
       List<EventSyncRequest> syncRequests) {
-    Key<Organization> orgKey = OfyUtil.createKey(orgKeyStr);
-    EventSourceInfo sourceInfo = validateOrgSecret(orgKey, orgSecret);
+    EventSourceInfo sourceInfo = validateOrgSecret(orgId, orgSecret);
 
     AdminUtil.executeSubtaskAsAdmin(
       AdminTaskType.SOURCE_EVENT_UPDATE,
@@ -78,8 +76,15 @@ public class SourceEventResource {
     }
   }
 
-  private static EventSourceInfo validateOrgSecret(Key<Organization> orgKey,
+  private static EventSourceInfo validateOrgSecret(String orgId,
       String orgSecret) {
+    if (orgId == null) {
+      throw ErrorResponseMsg.createException(
+        "'orgId' must be specified",
+        ErrorInfo.Type.BAD_REQUEST);
+    }
+    Key<Organization> orgKey =
+        Organization.createKey(orgId);
     EventSourceInfo sourceInfo =
         ofy().load().key(EventSourceInfo.createKey(orgKey)).now();
     if (sourceInfo == null) {


### PR DESCRIPTION
This avoids issues with the app id being stored in the key and having to change the key every time we test out the changes on a different karma exchange backend.
